### PR TITLE
fix watching blackhole directory

### DIFF
--- a/internal/directory_watcher/directory_watcher.go
+++ b/internal/directory_watcher/directory_watcher.go
@@ -36,6 +36,7 @@ func (w *WatchDirectory) Watch() error {
 				if event.Op&fsnotify.Create == fsnotify.Create {
 					action = w.MatchFunction(event.Name)
 					if action == 1 {
+						w.CallbackFunction(event.Name)
 					} else if action == 2 {
 						w.Watcher.Add(event.Name)
 					}


### PR DESCRIPTION
I noticed watching the blackhole directory was broken (probably by accident) in [this commit](https://github.com/ensingerphilipp/Premiumizearr-Nova/commit/b2792d07e626abb8e7272d9e7737e6b05ba3a224#diff-cb6bf37c4eed9c9a2fc30514957655f2b99f4cd4fdc1c16a5dc4e7fe15f917eaR37-R40). The callback function adding the file from the directory to the queue is no longer being called.

I added the call again and new files from the directory are being handled again.