### PR TITLE
fix: Use correct user and group for permissions

### DIFF
--- a/docker/root/etc/cont-init.d/30-config
+++ b/docker/root/etc/cont-init.d/30-config
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # permissions
-chown -R 1000:1000 \
+chown -R $PUID:$PGID \
     /data \
     /downloads \
     /transfers \

--- a/init/premiumizearrd.service
+++ b/init/premiumizearrd.service
@@ -2,8 +2,8 @@
 Description=Premiumizearr Daemon
 After=network.target
 [Service]
-User=1000
-Group=1000
+User=###USER###
+Group=###GROUP###
 UMask=0002
 Type=simple
 Environment=PREMIUMIZEARR_LOG_LEVEL=info

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-chown -R 1000:1000 /opt/premiumizearrd/
+chown -R $PUID:$PGID /opt/premiumizearrd/
+sed -i "" "s/###USER###/$PUID/g" /etc/systemd/system/premiumizearrd.service
+sed -i "" "s/###GROUP###/$PGID/g" /etc/systemd/system/premiumizearrd.service
 systemctl enable premiumizearrd.service
 systemctl daemon-reload
 systemctl start premiumizearrd.service


### PR DESCRIPTION
Fixes: #51

I have *NOT* tested these changes, but this should be all references to hard-coded users and groups.

This change will break, when PUID or PGID are not set (eg. local development). @ensingerphilipp Please advise whether I need to further adjust the scripts to also handle unset PUID and PGID variables.