### PR TITLE
Fix Premiumize transfer folder multipart field

### DIFF
--- a/pkg/premiumizeme/premiumizeme.go
+++ b/pkg/premiumizeme/premiumizeme.go
@@ -419,8 +419,9 @@ func createNZBRequest(file *os.File, url *url.URL, parentID string) (*http.Reque
 		return nil, err
 	}
 
-	io.Copy(part, file)
-	writer.Close()
+	if _, err := io.Copy(part, file); err != nil {
+		return nil, err
+	}
 
 	part, err = writer.CreateFormField("folder_id")
 
@@ -434,12 +435,17 @@ func createNZBRequest(file *os.File, url *url.URL, parentID string) (*http.Reque
 		return nil, err
 	}
 
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
 	request, err := http.NewRequest("POST", url.String(), body)
-	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	if err != nil {
 		return nil, err
 	}
+
+	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	return request, nil
 }
@@ -453,8 +459,9 @@ func createMagnetRequest(file *os.File, url *url.URL, parentID string) (*http.Re
 		return nil, err
 	}
 
-	io.Copy(part, file)
-	writer.Close()
+	if _, err := io.Copy(part, file); err != nil {
+		return nil, err
+	}
 
 	part, err = writer.CreateFormField("folder_id")
 
@@ -468,12 +475,17 @@ func createMagnetRequest(file *os.File, url *url.URL, parentID string) (*http.Re
 		return nil, err
 	}
 
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
 	request, err := http.NewRequest("POST", url.String(), body)
-	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	if err != nil {
 		return nil, err
 	}
+
+	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	return request, nil
 }
@@ -487,8 +499,9 @@ func createTorrentRequest(file *os.File, url *url.URL, parentID string) (*http.R
 		return nil, err
 	}
 
-	io.Copy(part, file)
-	writer.Close()
+	if _, err := io.Copy(part, file); err != nil {
+		return nil, err
+	}
 
 	part, err = writer.CreateFormField("folder_id")
 
@@ -502,12 +515,17 @@ func createTorrentRequest(file *os.File, url *url.URL, parentID string) (*http.R
 		return nil, err
 	}
 
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
 	request, err := http.NewRequest("POST", url.String(), body)
-	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	if err != nil {
 		return nil, err
 	}
+
+	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	return request, nil
 }

--- a/pkg/premiumizeme/premiumizeme_test.go
+++ b/pkg/premiumizeme/premiumizeme_test.go
@@ -1,0 +1,111 @@
+package premiumizeme
+
+import (
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateTransferRequestsIncludeFolderID(t *testing.T) {
+	tests := []struct {
+		name       string
+		extension  string
+		content    string
+		createFunc func(*os.File, *url.URL, string) (*http.Request, error)
+	}{
+		{
+			name:       "nzb",
+			extension:  ".nzb",
+			content:    "<nzb></nzb>",
+			createFunc: createNZBRequest,
+		},
+		{
+			name:       "magnet",
+			extension:  ".magnet",
+			content:    "magnet:?xt=urn:btih:123",
+			createFunc: createMagnetRequest,
+		},
+		{
+			name:       "torrent",
+			extension:  ".torrent",
+			content:    "torrent-bytes",
+			createFunc: createTorrentRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := createTempTransferFile(t, tt.extension, tt.content)
+			defer file.Close()
+
+			requestURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/api/transfer/create"}
+			req, err := tt.createFunc(file, requestURL, "target-folder-id")
+			if err != nil {
+				t.Fatalf("create request: %v", err)
+			}
+
+			fields := readMultipartFields(t, req)
+			if fields["folder_id"] != "target-folder-id" {
+				t.Fatalf("folder_id = %q, want %q", fields["folder_id"], "target-folder-id")
+			}
+			if fields["src"] != tt.content {
+				t.Fatalf("src = %q, want %q", fields["src"], tt.content)
+			}
+		})
+	}
+}
+
+func createTempTransferFile(t *testing.T, extension string, content string) *os.File {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "transfer"+extension)
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp transfer file: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open temp transfer file: %v", err)
+	}
+
+	return file
+}
+
+func readMultipartFields(t *testing.T, req *http.Request) map[string]string {
+	t.Helper()
+
+	contentType := req.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse content type %q: %v", contentType, err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("content type = %q, want multipart/form-data", mediaType)
+	}
+
+	reader := multipart.NewReader(req.Body, params["boundary"])
+	fields := make(map[string]string)
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read multipart part: %v", err)
+		}
+
+		value, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read multipart value: %v", err)
+		}
+		fields[part.FormName()] = strings.TrimSuffix(string(value), "\n")
+	}
+
+	return fields
+}


### PR DESCRIPTION
## Summary

Fixes Premiumize transfer creation so the configured transfer folder is sent inside the valid multipart request body for `.nzb`, `.magnet`, and `.torrent` uploads.

## Root cause

The multipart writer was closed immediately after writing `src`, before `folder_id` was added. That left `folder_id` outside the valid multipart body, so Premiumize could accept the transfer while ignoring the requested destination folder and defaulting to root.

## Changes

- Move `writer.Close()` until after `folder_id` is written in all transfer request builders.
- Check `io.Copy` and multipart close errors.
- Add focused tests that parse generated multipart requests and assert both `src` and `folder_id` are present.

## Validation

- `go test ./pkg/premiumizeme`
- `go test -vet=off ./...`

Plain `go test ./...` still hits existing vet diagnostics in unrelated packages.
