### PR TITLE
Fix nil pointer panic in BlackholeHandler on startup

### DIFF
--- a/internal/service/directory_watcher_service.go
+++ b/internal/service/directory_watcher_service.go
@@ -72,10 +72,10 @@ func (dw *DirectoryWatcherService) GetStatus() string {
 func (dw *DirectoryWatcherService) Start() {
 	log.Info("Starting directory watcher...")
 
-	dw.downloadsFolderID = utils.GetDownloadsFolderIDFromPremiumizeme(dw.premiumizemeClient, dw.config.TransferDirectory)
-
 	log.Info("Creating Queue...")
 	dw.Queue = stringqueue.NewStringQueue()
+
+	dw.downloadsFolderID = utils.GetDownloadsFolderIDFromPremiumizeme(dw.premiumizemeClient, dw.config.TransferDirectory)
 
 	log.Info("Starting uploads processor...")
 	go dw.processUploads()

--- a/internal/service/web_service_handlers.go
+++ b/internal/service/web_service_handlers.go
@@ -91,7 +91,7 @@ func (s *WebServerService) DownloadsHandler(w http.ResponseWriter, r *http.Reque
 func (s *WebServerService) BlackholeHandler(w http.ResponseWriter, r *http.Request) {
 	var resp BlackholeResponse
 
-	if s.directoryWatcherService == nil {
+	if s.directoryWatcherService == nil || s.directoryWatcherService.Queue == nil {
 		resp.Status = "Not Initialized"
 	} else {
 		for i, n := range s.directoryWatcherService.Queue.GetQueue() {


### PR DESCRIPTION
## Summary
Fixes #67

Fixes a nil pointer dereference panic that can occur shortly after startup, when the web server receives a request to `/blackhole` before `DirectoryWatcherService.Queue` has been initialized.

## Changes
- `DirectoryWatcherService.Start()`: create `Queue` before the premiumize.me API call that resolves `downloadsFolderID`, instead of after. The web server is already accepting requests at that point, so a request landing in that window hit a nil `Queue`.
- `BlackholeHandler`: additionally guard against a nil `Queue` as defense in depth, in case this code path is reached in a similar state again in the future.