### PR TITLE
Add per-Arr subfolders (#64)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,11 @@ func LoadOrCreateConfig(altConfigLocation string, _appCallback AppCallback) (Con
 	config.appCallback = _appCallback
 	config.altConfigLocation = altConfigLocation
 
+	if err := ValidateArrs(config.Arrs); err != nil {
+		log.Errorf("Invalid Arrs configuration: %s", err)
+		return config, ErrInvalidArrConfig
+	}
+
 	config.Save()
 
 	return config, nil
@@ -137,6 +142,12 @@ func loadConfigFromDisk(altConfigLocation string) (Config, error) {
 		updated = true
 	}
 
+	if configInterface["EnableArrSubfolders"] == nil {
+		log.Info("EnableArrSubfolders not set, setting to false")
+		config.EnableArrSubfolders = false
+		updated = true
+	}
+
 	if configInterface["PollBlackholeIntervalMinutes"] == nil {
 		log.Info("PollBlackholeIntervalMinutes not set, setting to 10")
 		config.PollBlackholeIntervalMinutes = 10
@@ -173,9 +184,9 @@ func defaultConfig() Config {
 	return Config{
 		PremiumizemeAPIKey: "xxxxxxxxx",
 		Arrs: []ArrConfig{
-			{Name: "Sonarr", URL: "http://127.0.0.1:8989", APIKey: "xxxxxxxxx", Type: Sonarr},
-			{Name: "Radarr", URL: "http://127.0.0.1:7878", APIKey: "xxxxxxxxx", Type: Radarr},
-			{Name: "Lidarr", URL: "http://127.0.0.1:8686", APIKey: "xxxxxxxxx", Type: Lidarr},
+			{Name: "sonarr", URL: "http://127.0.0.1:8989", APIKey: "xxxxxxxxx", Type: Sonarr},
+			{Name: "radarr", URL: "http://127.0.0.1:7878", APIKey: "xxxxxxxxx", Type: Radarr},
+			{Name: "lidarr", URL: "http://127.0.0.1:8686", APIKey: "xxxxxxxxx", Type: Lidarr},
 		},
 		BlackholeDirectory:              "",
 		PollBlackholeDirectory:          false,
@@ -189,6 +200,7 @@ func defaultConfig() Config {
 		DownloadSpeedLimit:              100,
 		EnableTlsCheck:                  false,
 		TransferOnlyMode:                false,
+		EnableArrSubfolders:             false,
 		ArrHistoryUpdateIntervalSeconds: 20,
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,11 +1,16 @@
 package config
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
 
 var (
 	ErrInvalidConfigFile      = errors.New("invalid Config File")
 	ErrFailedToFindConfigFile = errors.New("failed to find config file")
 	ErrFailedToSaveConfig     = errors.New("failed to save config")
+	ErrInvalidArrConfig       = errors.New("invalid arr config")
 )
 
 // ArrType enum for Sonarr/Radarr/Lidarr
@@ -21,10 +26,28 @@ const (
 )
 
 type ArrConfig struct {
+	// Name must be a slug (used as the download subfolder name locally and on pme)
 	Name   string  `yaml:"Name" json:"Name"`
 	URL    string  `yaml:"URL" json:"URL"`
 	APIKey string  `yaml:"APIKey" json:"APIKey"`
 	Type   ArrType `yaml:"Type" json:"Type"`
+}
+
+var arrNameSlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ValidateArrs checks that every Arr name is a valid, unique slug
+func ValidateArrs(arrs []ArrConfig) error {
+	seen := make(map[string]bool, len(arrs))
+	for _, arr := range arrs {
+		if !arrNameSlugPattern.MatchString(arr.Name) {
+			return fmt.Errorf("%w: %q is not a valid slug (only lowercase letters, digits and hyphens)", ErrInvalidArrConfig, arr.Name)
+		}
+		if seen[arr.Name] {
+			return fmt.Errorf("%w: name %q is used by more than one Arr", ErrInvalidArrConfig, arr.Name)
+		}
+		seen[arr.Name] = true
+	}
+	return nil
 }
 
 type Config struct {
@@ -52,6 +75,7 @@ type Config struct {
 	DownloadSpeedLimit    int  `yaml:"DownloadSpeedLimit" json:"DownloadSpeedLimit"`
 	EnableTlsCheck        bool `yaml:"EnableTlsCheck" json:"EnableTlsCheck"`
 	TransferOnlyMode      bool `yaml:"TransferOnlyMode" json:"TransferOnlyMode"`
+	EnableArrSubfolders   bool `yaml:"EnableArrSubfolders" json:"EnableArrSubfolders"`
 
 	ArrHistoryUpdateIntervalSeconds int `yaml:"ArrHistoryUpdateIntervalSeconds" json:"ArrHistoryUpdateIntervalSeconds"`
 }

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestValidateArrs(t *testing.T) {
+	tests := []struct {
+		name    string
+		arrs    []ArrConfig
+		wantErr bool
+	}{
+		{"empty list", []ArrConfig{}, false},
+		{"valid single slug", []ArrConfig{{Name: "sonarr"}}, false},
+		{"valid slug with hyphen", []ArrConfig{{Name: "sonarr-anime"}}, false},
+		{"valid slug with digits", []ArrConfig{{Name: "radarr-4k"}}, false},
+		{"valid distinct slugs", []ArrConfig{{Name: "sonarr"}, {Name: "radarr"}}, false},
+		{"uppercase rejected", []ArrConfig{{Name: "Sonarr"}}, true},
+		{"space rejected", []ArrConfig{{Name: "sonarr anime"}}, true},
+		{"empty name rejected", []ArrConfig{{Name: ""}}, true},
+		{"leading hyphen rejected", []ArrConfig{{Name: "-sonarr"}}, true},
+		{"trailing hyphen rejected", []ArrConfig{{Name: "sonarr-"}}, true},
+		{"double hyphen rejected", []ArrConfig{{Name: "sonarr--anime"}}, true},
+		{"duplicate name rejected", []ArrConfig{{Name: "sonarr"}, {Name: "sonarr"}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateArrs(tt.arrs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateArrs(%v) error = %v, wantErr %v", tt.arrs, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/directory_watcher/directory_watcher.go
+++ b/internal/directory_watcher/directory_watcher.go
@@ -63,6 +63,16 @@ func (w *WatchDirectory) Watch() error {
 	return nil
 }
 
+// AddWatchPath watches an additional directory on top of the root Path
+func (w *WatchDirectory) AddWatchPath(path string) error {
+	return w.Watcher.Add(filepath.Clean(path))
+}
+
+// RemoveWatchPath stops watching a directory previously added via AddWatchPath
+func (w *WatchDirectory) RemoveWatchPath(path string) error {
+	return w.Watcher.Remove(filepath.Clean(path))
+}
+
 func (w *WatchDirectory) UpdatePath(path string) error {
 	w.Watcher.Remove(w.Path)
 	w.Path = path

--- a/internal/service/directory_watcher_service.go
+++ b/internal/service/directory_watcher_service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ type DirectoryWatcherService struct {
 	status             string
 	downloadsFolderID  string
 	watchDirectory     *directory_watcher.WatchDirectory
+	arrFolders         map[string]string // Arr slug -> pme subfolder ID
 }
 
 const (
@@ -47,20 +49,35 @@ func (dw *DirectoryWatcherService) Init(premiumizemeClient *premiumizeme.Premium
 }
 
 func (dw *DirectoryWatcherService) ConfigUpdatedCallback(currentConfig config.Config, newConfig config.Config) {
-	if currentConfig.BlackholeDirectory != newConfig.BlackholeDirectory {
+	blackholeChanged := currentConfig.BlackholeDirectory != newConfig.BlackholeDirectory
+	transferChanged := currentConfig.TransferDirectory != newConfig.TransferDirectory
+	arrsChanged := !reflect.DeepEqual(currentConfig.Arrs, newConfig.Arrs)
+	toggleChanged := currentConfig.EnableArrSubfolders != newConfig.EnableArrSubfolders
+
+	if blackholeChanged {
 		log.Info("Blackhole directory changed, restarting directory watcher...")
 		log.Info("Running initial directory scan...")
 		go dw.directoryScan(dw.config.BlackholeDirectory)
 		dw.watchDirectory.UpdatePath(newConfig.BlackholeDirectory)
+
+		if dw.watchDirectory != nil {
+			for slug := range dw.arrFolders {
+				dw.watchDirectory.RemoveWatchPath(filepath.Join(currentConfig.BlackholeDirectory, slug))
+			}
+		}
 	}
 
-	if currentConfig.TransferDirectory != newConfig.TransferDirectory {
+	if transferChanged {
 		log.Info("TransferDirectory directory changed, changing directory watcher...")
 		dw.setTransferDirectory(newConfig.TransferDirectory)
 	}
 
 	if currentConfig.PollBlackholeDirectory != newConfig.PollBlackholeDirectory {
 		log.Info("Poll blackhole directory changed, restarting directory watcher...")
+	}
+
+	if blackholeChanged || transferChanged || arrsChanged || toggleChanged {
+		dw.resolveArrFolders()
 	}
 }
 
@@ -102,6 +119,7 @@ func (dw *DirectoryWatcherService) Start() {
 				time.Sleep(time.Duration(dw.config.PollBlackholeIntervalMinutes) * time.Minute)
 				log.Infof("Running directory scan of %s", dw.config.BlackholeDirectory)
 				dw.directoryScan(dw.config.BlackholeDirectory)
+				dw.scanArrFolders()
 				log.Infof("Scan complete, next scan in %d minutes", dw.config.PollBlackholeIntervalMinutes)
 			}
 		}()
@@ -113,6 +131,90 @@ func (dw *DirectoryWatcherService) Start() {
 			dw.addFileToQueue,
 		)
 		dw.watchDirectory.Watch()
+	}
+
+	dw.resolveArrFolders()
+}
+
+// clearArrFolders stops watching all known Arr subfolders and forgets their
+// pme IDs, without deleting anything on disk or on pme.
+func (dw *DirectoryWatcherService) clearArrFolders() {
+	dw.mu.Lock()
+	oldFolders := dw.arrFolders
+	dw.arrFolders = nil
+	dw.mu.Unlock()
+
+	if dw.watchDirectory != nil {
+		for slug := range oldFolders {
+			dw.watchDirectory.RemoveWatchPath(filepath.Join(dw.config.BlackholeDirectory, slug))
+		}
+	}
+}
+
+// resolveArrFolders ensures each configured Arr has a local blackhole subfolder
+// and a matching pme subfolder, and watches/scans it for existing files.
+func (dw *DirectoryWatcherService) resolveArrFolders() {
+	if !dw.config.EnableArrSubfolders {
+		dw.clearArrFolders()
+		return
+	}
+
+	newFolders := make(map[string]string, len(dw.config.Arrs))
+
+	for _, arr := range dw.config.Arrs {
+		id, err := utils.GetOrCreateSubfolderID(dw.premiumizemeClient, dw.downloadsFolderID, arr.Name)
+		if err != nil {
+			log.Errorf("Cannot resolve premiumize.me subfolder for Arr %s: %s", arr.Name, err)
+			continue
+		}
+		newFolders[arr.Name] = id
+
+		local := filepath.Join(dw.config.BlackholeDirectory, arr.Name)
+		if err := os.MkdirAll(local, os.ModePerm); err != nil {
+			log.Errorf("Cannot create blackhole subfolder for Arr %s: %s", arr.Name, err)
+			continue
+		}
+
+		if dw.watchDirectory != nil {
+			if err := dw.watchDirectory.AddWatchPath(local); err != nil {
+				log.Errorf("Cannot watch blackhole subfolder %s: %s", local, err)
+			}
+		}
+		dw.directoryScan(local)
+	}
+
+	dw.mu.Lock()
+	oldFolders := dw.arrFolders
+	dw.arrFolders = newFolders
+	dw.mu.Unlock()
+
+	configuredSlugs := make(map[string]bool, len(dw.config.Arrs))
+	for _, arr := range dw.config.Arrs {
+		configuredSlugs[arr.Name] = true
+	}
+
+	for slug := range oldFolders {
+		if configuredSlugs[slug] {
+			continue
+		}
+		if dw.watchDirectory != nil {
+			dw.watchDirectory.RemoveWatchPath(filepath.Join(dw.config.BlackholeDirectory, slug))
+		}
+		log.Infof("Arr %s no longer configured, local/premiumize subfolder is kept but no longer watched", slug)
+	}
+}
+
+func (dw *DirectoryWatcherService) scanArrFolders() {
+	if !dw.config.EnableArrSubfolders {
+		return
+	}
+
+	for _, arr := range dw.config.Arrs {
+		local := filepath.Join(dw.config.BlackholeDirectory, arr.Name)
+		if _, err := os.Stat(local); err != nil {
+			continue
+		}
+		dw.directoryScan(local)
 	}
 }
 
@@ -144,6 +246,10 @@ func (dw *DirectoryWatcherService) checkFile(path string) int {
 	}
 
 	if fi.IsDir() {
+		if dw.isConfiguredArrSlug(filepath.Base(path)) {
+			log.Tracef("Directory %s is a configured Arr subfolder, handled separately", path)
+			return 0
+		}
 		log.Errorf("Directory created in blackhole %s ignoring (Warning premiumizearrd does not look in subfolders!)", path)
 		return 2
 	}
@@ -154,6 +260,18 @@ func (dw *DirectoryWatcherService) checkFile(path string) int {
 	} else {
 		return 0
 	}
+}
+
+func (dw *DirectoryWatcherService) isConfiguredArrSlug(slug string) bool {
+	if !dw.config.EnableArrSubfolders {
+		return false
+	}
+	for _, arr := range dw.config.Arrs {
+		if arr.Name == slug {
+			return true
+		}
+	}
+	return false
 }
 
 func (dw *DirectoryWatcherService) addFileToQueue(path string) {
@@ -178,8 +296,16 @@ func (dw *DirectoryWatcherService) processUploads() {
 		if filePath != "" {
 			log.Debugf("Processing %s", filePath)
 			dw.mu.RLock()
-			folderID := dw.downloadsFolderID
+			folderID, ok, slug := resolveTargetFolderID(filePath, dw.config.BlackholeDirectory, dw.downloadsFolderID, dw.arrFolders)
 			dw.mu.RUnlock()
+			if !ok && slug != "" {
+				folderID, ok = dw.resolveSingleArrFolder(slug)
+			}
+			if !ok {
+				log.Errorf("No resolved target folder for %s, skipping upload", filePath)
+				time.Sleep(time.Second * time.Duration(sleepTimeSeconds))
+				continue
+			}
 			err := dw.premiumizemeClient.CreateTransfer(filePath, folderID)
 			if err != nil {
 				switch err.Error() {
@@ -206,6 +332,37 @@ func (dw *DirectoryWatcherService) processUploads() {
 			log.Errorf("Received %s from blackhole Queue. Appears to be an empty path.")
 		}
 	}
+}
+
+func (dw *DirectoryWatcherService) resolveSingleArrFolder(slug string) (string, bool) {
+	if !dw.config.EnableArrSubfolders {
+		return "", false
+	}
+
+	id, err := utils.GetOrCreateSubfolderID(dw.premiumizemeClient, dw.downloadsFolderID, slug)
+	if err != nil {
+		log.Errorf("Cannot resolve premiumize.me subfolder for Arr %s: %s", slug, err)
+		return "", false
+	}
+
+	dw.mu.Lock()
+	if dw.arrFolders == nil {
+		dw.arrFolders = map[string]string{}
+	}
+	dw.arrFolders[slug] = id
+	dw.mu.Unlock()
+
+	return id, true
+}
+
+func resolveTargetFolderID(filePath, blackholeDir, mainFolderID string, arrFolders map[string]string) (folderID string, ok bool, slug string) {
+	if filepath.Dir(filePath) == filepath.Clean(blackholeDir) {
+		return mainFolderID, true, ""
+	}
+
+	slug = filepath.Base(filepath.Dir(filePath))
+	id, found := arrFolders[slug]
+	return id, found, slug
 }
 
 func (dw *DirectoryWatcherService) setTransferDirectory(newDir string) {

--- a/internal/service/directory_watcher_service_test.go
+++ b/internal/service/directory_watcher_service_test.go
@@ -1,0 +1,33 @@
+package service
+
+import "testing"
+
+func TestResolveTargetFolderID(t *testing.T) {
+	blackholeDir := "/blackhole"
+	mainFolderID := "main-folder-id"
+	arrFolders := map[string]string{
+		"sonarr": "sonarr-folder-id",
+	}
+
+	tests := []struct {
+		name     string
+		filePath string
+		wantID   string
+		wantOK   bool
+		wantSlug string
+	}{
+		{"file in main folder", "/blackhole/movie.torrent", mainFolderID, true, ""},
+		{"file in resolved Arr subfolder", "/blackhole/sonarr/episode.nzb", "sonarr-folder-id", true, "sonarr"},
+		{"file in unresolved subfolder", "/blackhole/radarr/movie.magnet", "", false, "radarr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok, slug := resolveTargetFolderID(tt.filePath, blackholeDir, mainFolderID, arrFolders)
+			if id != tt.wantID || ok != tt.wantOK || slug != tt.wantSlug {
+				t.Fatalf("resolveTargetFolderID(%q) = (%q, %v, %q), want (%q, %v, %q)",
+					tt.filePath, id, ok, slug, tt.wantID, tt.wantOK, tt.wantSlug)
+			}
+		})
+	}
+}

--- a/internal/service/transfer_manager_service.go
+++ b/internal/service/transfer_manager_service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -34,6 +35,8 @@ type TransferManagerService struct {
 	downloadsFolderID    string
 	failedDownloadsMutex *sync.Mutex
 	failedDownloads      map[string]time.Time // Maps item name to failure timestamp
+	arrFoldersMutex      *sync.Mutex
+	arrFolders           map[string]string // Arr slug -> premiumize.me subfolder ID
 }
 
 // Handle
@@ -50,6 +53,8 @@ func (t TransferManagerService) New() TransferManagerService {
 	t.downloadsFolderID = ""
 	t.failedDownloadsMutex = &sync.Mutex{}
 	t.failedDownloads = make(map[string]time.Time, 0)
+	t.arrFoldersMutex = &sync.Mutex{}
+	t.arrFolders = make(map[string]string, 0)
 	return t
 }
 
@@ -119,21 +124,64 @@ func (t *TransferManagerService) CleanUpDownloadDir() {
 }
 
 func (manager *TransferManagerService) ConfigUpdatedCallback(currentConfig config.Config, newConfig config.Config) {
-	if currentConfig.DownloadsDirectory != newConfig.DownloadsDirectory {
+	downloadsDirChanged := currentConfig.DownloadsDirectory != newConfig.DownloadsDirectory
+	transferChanged := currentConfig.TransferDirectory != newConfig.TransferDirectory
+	arrsChanged := !reflect.DeepEqual(currentConfig.Arrs, newConfig.Arrs)
+	toggleChanged := currentConfig.EnableArrSubfolders != newConfig.EnableArrSubfolders
+
+	if downloadsDirChanged {
 		log.Trace("Inside ConfigUpdatedCallback")
 		manager.CleanUpDownloadDir()
 	}
 
-	if currentConfig.TransferDirectory != newConfig.TransferDirectory {
+	if transferChanged {
 		log.Trace("Updating Transfer Directory in TransferManagerService")
 		newDir := newConfig.TransferDirectory
 		newID := utils.GetDownloadsFolderIDFromPremiumizeme(manager.premiumizemeClient, newDir)
 		manager.downloadsFolderID = newID
 	}
+
+	if downloadsDirChanged || transferChanged || arrsChanged || toggleChanged {
+		manager.resolveArrFolders()
+	}
+}
+
+func (manager *TransferManagerService) clearArrFolders() {
+	manager.arrFoldersMutex.Lock()
+	defer manager.arrFoldersMutex.Unlock()
+	manager.arrFolders = make(map[string]string, 0)
+}
+
+func (manager *TransferManagerService) resolveArrFolders() {
+	if !manager.config.EnableArrSubfolders {
+		manager.clearArrFolders()
+		return
+	}
+
+	newFolders := make(map[string]string, len(manager.config.Arrs))
+
+	for _, arr := range manager.config.Arrs {
+		id, err := utils.GetOrCreateSubfolderID(manager.premiumizemeClient, manager.downloadsFolderID, arr.Name)
+		if err != nil {
+			log.Errorf("Cannot resolve premiumize.me subfolder for Arr %s: %s", arr.Name, err)
+			continue
+		}
+		newFolders[arr.Name] = id
+
+		local := filepath.Join(manager.config.DownloadsDirectory, arr.Name)
+		if err := os.MkdirAll(local, os.ModePerm); err != nil {
+			log.Errorf("Cannot create downloads subfolder for Arr %s: %s", arr.Name, err)
+		}
+	}
+
+	manager.arrFoldersMutex.Lock()
+	manager.arrFolders = newFolders
+	manager.arrFoldersMutex.Unlock()
 }
 
 func (manager *TransferManagerService) Run(interval time.Duration) {
 	manager.downloadsFolderID = utils.GetDownloadsFolderIDFromPremiumizeme(manager.premiumizemeClient, manager.config.TransferDirectory)
+	manager.resolveArrFolders()
 	for {
 		manager.runningTask = true
 		manager.TaskUpdateTransfersList()
@@ -200,10 +248,34 @@ func (manager *TransferManagerService) TaskCheckPremiumizeDownloadsFolder() {
 		return
 	}
 
-	items, err := manager.premiumizemeClient.ListFolder(manager.downloadsFolderID)
+	if !manager.checkFolder(manager.downloadsFolderID, manager.config.DownloadsDirectory) {
+		return
+	}
+
+	if !manager.config.EnableArrSubfolders {
+		return
+	}
+
+	manager.arrFoldersMutex.Lock()
+	arrFolders := make(map[string]string, len(manager.arrFolders))
+	for slug, folderID := range manager.arrFolders {
+		arrFolders[slug] = folderID
+	}
+	manager.arrFoldersMutex.Unlock()
+
+	for slug, folderID := range arrFolders {
+		localDir := filepath.Join(manager.config.DownloadsDirectory, slug)
+		if !manager.checkFolder(folderID, localDir) {
+			return // SimultaneousDownloads cap reached
+		}
+	}
+}
+
+func (manager *TransferManagerService) checkFolder(premiumizeFolderID, localDir string) bool {
+	items, err := manager.premiumizemeClient.ListFolder(premiumizeFolderID)
 	if err != nil {
 		log.Errorf("Error listing downloads folder: %s", err.Error())
-		return
+		return true
 	}
 
 	for _, item := range items {
@@ -219,16 +291,16 @@ func (manager *TransferManagerService) TaskCheckPremiumizeDownloadsFolder() {
 			continue
 		}
 
-		if manager.countDownloads() < manager.config.SimultaneousDownloads {
-			log.Debugf("Processing completed item: %s", item.Name)
-			manager.HandleFinishedItem(item, manager.config.DownloadsDirectory)
-			//Sleep for one Second to let Asynchronous Downloads Start and Update
-			time.Sleep(time.Second * 1)
-		} else {
+		if manager.countDownloads() >= manager.config.SimultaneousDownloads {
 			log.Debugf("Not processing any more transfers, %d are running and cap is %d", manager.countDownloads(), manager.config.SimultaneousDownloads)
-			break
+			return false
 		}
+
+		log.Debugf("Processing completed item: %s", item.Name)
+		manager.HandleFinishedItem(item, localDir, premiumizeFolderID)
+		time.Sleep(time.Second * 1)
 	}
+	return true
 }
 
 func (manager *TransferManagerService) updateTransfers(transfers []premiumizeme.Transfer) {
@@ -296,7 +368,7 @@ func (manager *TransferManagerService) isDownloadInCooldown(itemName string) boo
 	return false
 }
 
-func (manager *TransferManagerService) HandleFinishedItem(item premiumizeme.Item, downloadDirectory string) {
+func (manager *TransferManagerService) HandleFinishedItem(item premiumizeme.Item, downloadDirectory string, premiumizeParentFolderID string) {
 	if manager.downloadExists(item.Name) {
 		log.Tracef("Transfer %s is already downloading", item.Name)
 		return
@@ -306,7 +378,7 @@ func (manager *TransferManagerService) HandleFinishedItem(item premiumizeme.Item
 	if item.Type == "file" {
 		log.Tracef("Handling Item Type File in finished Transfer %s", item.Name)
 
-		id, err := manager.premiumizemeClient.CreateFolder(item.Name+".folder", &manager.downloadsFolderID)
+		id, err := manager.premiumizemeClient.CreateFolder(item.Name+".folder", &premiumizeParentFolderID)
 		if err != nil {
 			log.Errorf("cannot create Folder for Single File Download! %+v", err)
 			return

--- a/internal/service/web_service_config_routes.go
+++ b/internal/service/web_service_config_routes.go
@@ -34,6 +34,13 @@ func (s *WebServerService) ConfigHandler(w http.ResponseWriter, r *http.Request)
 			})
 			return
 		}
+		if err := config.ValidateArrs(newConfig.Arrs); err != nil {
+			EncodeAndWriteConfigChangeResponse(w, &ConfigChangeResponse{
+				Succeeded: false,
+				Status:    err.Error(),
+			})
+			return
+		}
 		s.config.UpdateConfig(newConfig)
 		EncodeAndWriteConfigChangeResponse(w, &ConfigChangeResponse{
 			Succeeded: true,

--- a/internal/service/web_service_handlers.go
+++ b/internal/service/web_service_handlers.go
@@ -31,6 +31,7 @@ func (s *WebServerService) TransfersHandler(w http.ResponseWriter, r *http.Reque
 type BlackholeFile struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
+	Arr  string `json:"arr"`
 }
 type BlackholeResponse struct {
 	BlackholeFiles []BlackholeFile `json:"data"`
@@ -96,9 +97,14 @@ func (s *WebServerService) BlackholeHandler(w http.ResponseWriter, r *http.Reque
 	} else {
 		for i, n := range s.directoryWatcherService.Queue.GetQueue() {
 			name := path.Base(n)
+			arr := ""
+			if path.Dir(n) != path.Clean(s.config.BlackholeDirectory) {
+				arr = path.Base(path.Dir(n))
+			}
 			resp.BlackholeFiles = append(resp.BlackholeFiles, BlackholeFile{
 				ID:   i,
 				Name: name,
+				Arr:  arr,
 			})
 		}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -118,6 +118,22 @@ func GetDownloadsFolderIDFromPremiumizeme(premiumizemeClient *premiumizeme.Premi
 	return downloadsFolderID
 }
 
+// GetOrCreateSubfolderID finds a folder by name directly under parentID, creating it if missing
+func GetOrCreateSubfolderID(premiumizemeClient *premiumizeme.Premiumizeme, parentID string, folderName string) (string, error) {
+	items, err := premiumizemeClient.ListFolder(parentID)
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range items {
+		if item.Type == "folder" && item.Name == folderName {
+			return item.ID, nil
+		}
+	}
+
+	return premiumizemeClient.CreateFolder(folderName, &parentID)
+}
+
 func EnvOrDefault(envName string, defaultValue string) string {
 	envValue := os.Getenv(envName)
 	if len(envValue) == 0 {

--- a/web/src/pages/Config.svelte
+++ b/web/src/pages/Config.svelte
@@ -35,10 +35,19 @@
     DownloadSpeedLimit: 100,
     EnableTlsCheck: false,
     TransferOnlyMode: false,
+    EnableArrSubfolders: false,
     Arrs: [],
   };
   const ERR_SAVE = "Error Saving Config";
   const ERR_TEST = "Error Testing *arr client";
+
+  function slugify(value) {
+    return value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  }
+
+  function trimSlugEdges(value) {
+    return value.replace(/^-+|-+$/g, "");
+  }
 
   let arrTesting = [];
   let arrTestIcons = [];
@@ -110,7 +119,7 @@
 
   function AddArr() {
     config.Arrs.push({
-      Name: "New Arr",
+      Name: `new-arr-${config.Arrs.length + 1}`,
       URL: "http://127.0.0.1:1234",
       APIKey: "xxxxxxxx",
       Type: "Sonarr",
@@ -206,7 +215,11 @@
                 bind:value={arr.Name}
                 disabled={inputDisabled}
                 on:input={() => {
+                  arr.Name = slugify(arr.Name);
                   UntestArr(i);
+                }}
+                on:blur={() => {
+                  arr.Name = trimSlugEdges(arr.Name);
                 }}
               />
               <TextInput
@@ -339,6 +352,11 @@
           disabled={inputDisabled}
           bind:toggled={config.EnableTlsCheck}
           labelText="Check TLS-Certificate at Download (enabling can break certain CDNs)"
+        />
+        <Toggle
+          disabled={inputDisabled}
+          bind:toggled={config.EnableArrSubfolders}
+          labelText="Use per-Arr subfolders (Blackhole/Downloads/premiumize.me), based on each Arr's Name"
         />
         <TextInput
           type="number"

--- a/web/src/pages/Info.svelte
+++ b/web/src/pages/Info.svelte
@@ -171,6 +171,7 @@
           headers={[
             { key: "id", value: "Pos" },
             { key: "name", value: "Name", sort: false },
+            { key: "arr", value: "Arr", sort: false },
           ]}
           APIpath="api/blackhole"
           zebra={true}


### PR DESCRIPTION
## Summary
Relates to #64

Adds an opt-in feature (`EnableArrSubfolders` toggle in the Web UI) that gives each configured *Arr instance its own subfolder — locally under Blackhole/Downloads, and on pme. Files placed directly in the main Blackhole folder keep working exactly as before.

**This is a draft, opened for early feedback and testing — not yet proposed as final/ready to merge.** Would appreciate testing from anyone running multiple instances.

## Changes
- `EnableArrSubfolders` config toggle (default off), validated Arr names as slugs (`ValidateArrs`), enforced both on config save and on daemon startup
- Live slug-normalization for the Arr name field in the Web UI
- Per-Arr subfolder resolution/creation on both the upload side (`DirectoryWatcherService`) and the download side (`TransferManagerService`)
- Blackhole table in the Web UI now shows which Arr (if any) a queued file belongs to

## How to test
1. Enable "Use per-Arr subfolders" under Download Settings
2. Configure at least one Arr with a valid slug name
3. Point that Arr's download client at `<BlackholeDirectory>/<arr-name>/`
4. Confirm uploads/downloads land in the corresponding pme/local subfolder, and that files in the main Blackhole folder still work as before
