### PR TITLE
Add project contract and verification gate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,33 @@
+name: Verify
+
+# PR-only on purpose: scripts/verify is intentionally red until the
+# baseline-cleanup task (see PROJECT.md). We do not add a push-to-main trigger
+# while main would be knowingly red; it can be added later if useful.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify (scripts/verify)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.2
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Run verification gate
+        run: bash scripts/verify

--- a/.qwen/review-rules.md
+++ b/.qwen/review-rules.md
@@ -1,0 +1,62 @@
+# Review rules — Premiumizearr-Nova
+
+Project-specific review invariants, applied to all changes (human or agent).
+`scripts/verify` enforces the mechanical subset automatically; the rest are
+review-time invariants. The gate must not be weakened (contract changes
+require explicit human approval).
+
+## Mechanical gate (must pass: `bash scripts/verify`)
+
+1. All tracked Go files gofmt-clean.
+2. `go vet ./...` clean.
+3. Production-style Go build succeeds (`CGO_ENABLED=0`, tags `netgo
+   osusergo`, static).
+4. `go test -race ./...` clean.
+5. `npm ci` succeeds in `web/` (lockfile in sync with `package.json`).
+6. Web production build (`npm run build`) succeeds.
+
+## Prohibitions
+
+- No `-vet=off`, no vet suppressions, no nolint-style comments, no exclusions,
+  no weakened checks — in code or in the gate.
+- No product-source edits whose only purpose is to make the gate green (while
+  the gate is intentionally red, gate failures are reported, not silently
+  "fixed").
+- No API keys or other secrets in logs, error messages, or test fixtures
+  (premiumize.me key, *arr keys); request URLs that embed keys must not be
+  logged.
+- No removal or breaking change of exported symbols under `pkg/` without a
+  recorded public-API assessment (this is a public Go module — HITL).
+- No net-new product behavior that does not trace to an approved objective,
+  GitHub issue, or approved planning decision.
+
+## Change-class rules
+
+- **Bug fixes**: add a failing-first regression test where reasonably feasible
+  (if deterministic reproduction is not reasonably feasible, document why and
+  provide the strongest deterministic verification available); fix narrowly (no
+  unrelated refactoring in the same change).
+- **Behavior-preserving hygiene**: must be behavior-preserving (formatting,
+  vet defect fixes per intended behavior, test infrastructure, toolchain/CI
+  alignment). Vet findings are fixed individually, never blanket-mechanical.
+- **Concurrency changes**: minimal local synchronization (mutex/atomic/safe
+  snapshot); must include `go test -race` evidence exercising the changed
+  path; no restructuring of config propagation or service boundaries (HITL).
+- **Config changes**: adding/changing/renaming a config field must identify
+  and update every relevant `ConfigUpdatedCallback` / runtime consumer;
+  preserve/update the YAML and JSON persistence tags as appropriate; update
+  the web Config UI (`web/src/pages/Config.svelte`) when the field is
+  user-configurable there; add/update tests where feasible.
+- **Dependency changes**: `npm ci` must pass (lockfile updated via npm, no
+  hand-edits); major dependency upgrades and the Go `go` directive require
+  HITL.
+- **Toolchain pin consistency**: `go.mod` (`go 1.23.0` / `toolchain
+  go1.24.2`), CI (`setup-go 1.24.2`, `setup-node 22`), and the
+  `scripts/verify` preflight (`GOTOOLCHAIN=local`, local Go >= 1.24.2) must
+  stay consistent; `go.mod` is never silently rewritten to align numbers.
+
+## Test quality
+
+- Deterministic: `httptest` for HTTP (premiumize.me, *arr), `t.TempDir` for
+  files, no network, avoid sleep-based timing.
+- Test meaningful behavior, not coverage numbers (no coverage floor).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,257 @@
+# ARCHITECTURE.md — Premiumizearr-Nova
+
+Current architecture, component boundaries, approved technical decisions, and
+verified known risks. For goals/scope/change policy see `PROJECT.md`.
+
+## System overview
+
+A single Go daemon (`premiumizearrd`) serving a Svelte web UI from the same
+HTTP server. Two transfer pipelines plus a configuration/status API:
+
+```
+*arr (Sonarr/Radarr/Lidarr)
+  │ blackhole: .nzb/.magnet/.torrent files
+  ▼
+BlackholeDirectory ──(fsnotify watch, or poll every N min)──▶
+  DirectoryWatcherService ──▶ stringqueue ──▶ processUploads (single goroutine)
+                                                   │ premiumize.me /transfer/create (multipart)
+                                                   ▼
+                                              premiumize.me
+  │ transfers land in the TransferDirectory folder (default "arrDownloads",
+  │ auto-created on Premiumize)
+  ▼
+TransferManagerService (15s loop)
+  ├── transfers in error status → fuzzy-matched against *arr history
+  │     → history item marked failed in the *arr + transfer deleted
+  └── completed folders → recursive download via `wget` subprocess
+        → DownloadsDirectory/<folder>/
+        → Premiumize folder deleted on success; 30-min in-memory cooldown on failure
+        (TransferOnlyMode disables this side entirely)
+
+WebServerService: gorilla/mux on bindIP:bindPort (default 0.0.0.0:8182),
+serves the SPA from ./static + JSON API. No authentication by design.
+```
+
+## Component boundaries (Go)
+
+| Component | Path | Responsibility |
+|---|---|---|
+| Entry / wiring | `cmd/premiumizearrd/` | Flags/env, version banner, manual wiring of config → premiumize.me client → 4 services → `ConfigUpdatedCallback` fan-out. No DI framework, no signal handling/graceful shutdown. |
+| Config | `internal/config/` | YAML load/save, defaults, missing-field backfill, docker dir overrides, `UpdateConfig` (whole-struct replace + save). |
+| *arr clients | `internal/arr/` | Per-arr wrappers over `golift.io/starr` (sonarr/radarr/lidarr); fuzzy filename matching; cached history; `IArr` interface. |
+| Services | `internal/service/` | `TransferManagerService`, `DirectoryWatcherService`, `WebServerService`, `ArrsManagerService`. `service.go` declares a `Service` interface no service implements (dead code, see roadmap). |
+| fsnotify wrapper | `internal/directory_watcher/` | Watch directory, match/callback hooks. |
+| Downloader | `internal/progress_downloader/` | `wget` subprocess via `stdbuf`, regex progress parsing into `WriteCounter`. |
+| Helpers | `internal/utils/` | Docker detection, writeability probe, env defaults, folder-ID resolution; (dead: `Unzip`, `StringInSlice`). |
+| Premiumize.me API | `pkg/premiumizeme/` | REST client (API key in query string). Legacy zip-API methods unused. **Public Go module surface.** The only package with tests. |
+| Queue | `pkg/stringqueue/` | Mutex string queue. |
+| (stub) | `pkg/clouddownloader/` | Empty interface stub, entirely unused. **Public Go module surface.** |
+
+## Pipeline behavior (current, as built)
+
+### Blackhole → Premiumize
+
+- fsnotify watch, or polling every `PollBlackholeIntervalMinutes` when
+  `PollBlackholeDirectory` is set (poll goroutine only starts if the flag is
+  already true at startup — toggling live does nothing).
+- Extensions `.nzb`/`.magnet`/`.torrent` only; subdirectories are **not**
+  recursed (documented limitation).
+- One uploader goroutine processes the queue sequentially. After a successful
+  create (or "already uploaded") the blackhole file is deleted.
+- Other errors: file is popped but neither re-queued nor deleted (known bug,
+  see Known risks). Error classification is exact-string matching on
+  `err.Error()`.
+
+### Premiumize → local
+
+- 15s polling loop (hardcoded in `app.go`).
+- Single-file items are wrapped in a `.folder` and moved (two-phase, completed
+  on the next poll).
+- Folders download recursively; each file via `wget -c` (resumable),
+  `--limit-rate=<DownloadSpeedLimit>M`, `--no-check-certificate` when
+  `EnableTlsCheck=false` (the default).
+- Concurrency capped by `SimultaneousDownloads` via the `countDownloads()`
+  heuristic (see Known risks).
+- Failed items get a 30-minute in-memory cooldown; on success the Premiumize
+  folder is deleted.
+- `CleanUpDownloadDirPeriod` deletes files older than 4 days from the
+  downloads directory at startup.
+- `TransferOnlyMode` disables this pipeline entirely.
+
+### *arr integration
+
+- `golift.io/starr` client per arr; history cached per
+  `ArrHistoryUpdateIntervalSeconds` (default 20s), most recent 1000 records.
+- Fuzzy filename matching (strips `.nzb`/`.magnet`/`.torrent`, media
+  extensions, spaces/periods/dashes/underscores; lowercased).
+- Errored transfer + history match → `Fail()` on the history item in the *arr
+  + `DeleteTransfer` on premiumize.me (spawned as a goroutine every 15s per
+  still-errored transfer — see Known risks).
+
+## Configuration & persistence
+
+- YAML at `<config-dir>/config.yaml` (env `PREMIUMIZEARR_CONFIG_DIR_PATH` or
+  flag `-config`); auto-created from defaults; saved on load (field backfill)
+  and on every API update.
+- `POST /api/config` replaces the **entire** config struct, fires each
+  service's `ConfigUpdatedCallback`, then saves. No field-level validation.
+- Docker (`/.dockerenv` detection): blank `BlackholeDirectory` /
+  `DownloadsDirectory` are overridden to `/blackhole` / `/downloads` and
+  persisted.
+- **No database.** Runtime state (download list, failure cooldowns, transfer
+  cache) is in-memory only and lost on restart.
+- Logging: logrus → console + lumberjack-rotated files
+  (`premiumizearr.{general,info,error}.log`), 100MB / 1 backup / 1-day
+  retention.
+- API keys (premiumize.me + *arr) stored in plaintext in `config.yaml`
+  (0644) and exposed via `GET /api/config`.
+
+## External systems & runtime dependencies
+
+- premiumize.me REST API (API key in query strings).
+- Sonarr/Radarr/Lidarr via `golift.io/starr`.
+- `wget` + `stdbuf` host binaries — hard runtime dependency (installed in the
+  Docker image; approved current design, native downloader is a roadmap
+  candidate).
+- Google Fonts CDN (referenced by `index.html`).
+
+## Web frontend
+
+- Svelte 3 + Carbon Components, webpack 5; two tabs (Info, Config).
+- `web/public/index.html` is a Go `html/template` (`WebRoot` injected) rendered
+  at runtime from `./static/index.html`.
+- Client-side polling of `/api/*` every 2–5s.
+- Build: `web/dist` → `build/static` → served from `./static` **relative to the
+  process CWD** (systemd unit sets `WorkingDirectory`, Docker sets `WORKDIR`;
+  binary installs rely on convention).
+
+## Build, release, CI
+
+- `Makefile`: `make web` (`npm i` + webpack), `make build` (static:
+  `CGO_ENABLED=0`, tags `netgo osusergo`).
+- goreleaser (`.goreleaser.yaml`, `.prerelease.goreleaser.yaml`): linux/windows
+  amd64/arm64 archives, deb (nfpms), GHCR Docker images (linuxserver alpine
+  base, s6), manifests.
+- CI: `build.yml` (release/snapshot via goreleaser on tags/PRs) — **separate
+  from the verify job**.
+- New: `verify.yml` — PR-triggered, runs `scripts/verify` (below).
+- Version 1.5.1 is hardcoded manually (banner in `main.go`, README, git tag).
+
+## Approved technical decisions
+
+1. **Node standard: 22.** Pinned explicitly wherever the toolchain is used
+   (CI via `actions/setup-node`); never rely on runner preinstalled defaults.
+   Node 24 later as normal maintenance.
+2. **Go toolchain split (intentional).** `go.mod` declares `go 1.23.0`
+   (minimum project floor) + `toolchain go1.24.2` (the project Go toolchain:
+   dev on Go 1.24.2, CI pins `setup-go 1.24.2`, verification runs with
+   `GOTOOLCHAIN=local` and requires local Go >= 1.24.2). Do not raise the go
+   directive merely to align numbers; a floor change is an explicit future
+   maintenance decision (HITL).
+3. **Verification gate:** one deterministic command, `scripts/verify` — spec
+   below. Never weakened.
+4. **Baseline policy:** one-time behavior-preserving cleanup task (defined in
+   PROJECT.md) brings the gate green; no suppressions, no `-vet=off`, no
+   exclusions, no weakened checks.
+5. **Race remediation policy:** minimal local synchronization (mutex/atomic/
+   safe snapshot) preserving architecture and observable behavior; treat
+   races as individual bugs (reproduce → `go test -race` test → narrow fix).
+   No restructuring of config propagation or service boundaries without HITL.
+6. **wget as the download mechanism:** approved current design.
+7. **No built-in auth:** out of current scope (roadmap candidate requiring
+   HITL); the approved current security boundary is an authenticated reverse
+   proxy / trusted network.
+8. **`pkg/` is the public Go module API surface:** no removal/breaking change
+   of exported symbols without a public-API assessment (HITL).
+9. **CI verify job:** `pull_request`-triggered only for now (no push-to-main
+   trigger while the gate is intentionally red pending baseline cleanup).
+   After the baseline-cleanup PR makes verify green, mark it a required merge
+   check; a push-to-main trigger can be added later if useful. The
+   release/Goreleaser workflow stays separate and is untouched by the verify
+   work.
+
+## scripts/verify (the gate)
+
+Bash, run from the repo root, `set -euo pipefail`. Never skips mandatory
+checks; never downloads or installs toolchains (verification exports
+`GOTOOLCHAIN=local`); fails with actionable errors on the first failure.
+
+**Preflight** (each failure is actionable):
+
+- Go: `go` present; the script exports `GOTOOLCHAIN=local` so verification
+  always uses the locally provisioned toolchain and never downloads one; the
+  local Go version is reported and must be >= 1.24.2 (go.mod's `go 1.23.0` /
+  `toolchain go1.24.2` is never edited to make this pass).
+- Node major == 22; npm present.
+- C compiler resolvable (`cc`/`gcc`/`clang`) — required for `go test -race`.
+
+**Mandatory checks, in order (any failure fails the gate):**
+
+1. gofmt clean over tracked Go files:
+   `git ls-files -z '*.go' | xargs -0 gofmt -l` → must be empty (offenders
+   listed).
+2. `go vet ./...` clean.
+3. Production-style build:
+   `CGO_ENABLED=0 go build -tags 'netgo osusergo' -ldflags '-extldflags
+   "-static"' ./cmd/premiumizearrd` → temp dir.
+4. `go test -race ./...` clean.
+5. `cd web && npm ci` (locked dependency graph).
+6. `cd web && npm run build` (production webpack build).
+
+**Gate state:** red on `planning/project-contract` by design (pre-existing
+gofmt/vet debt at check 1); do not weaken.
+
+## Known risks & limitations (verified, not yet fixed)
+
+**Bugs (backlog; see PROJECT.md):**
+
+1. Stranded blackhole files + exact-string error matching (pipeline above).
+2. Data races:
+   - `*config.Config` mutated by `POST /api/config` (`UpdateConfig`) while the
+     15s poll loops read fields (`SimultaneousDownloads`, `TransferOnlyMode`,
+     …).
+   - `TransferManagerService.status`/`runningTask`/`lastUpdated` written
+     unlocked, read by web handlers.
+   - `DirectoryWatcherService.downloadsFolderID` written unlocked in `Start`,
+     read under `mu` elsewhere.
+   - `WebServerService.ConfigUpdatedCallback` does `srv.Close()` + `Start()`
+     from a handler goroutine and overwrites the global `indexBytes`.
+3. `HandleErrorTransfer` goroutine storm: spawned every 15s per still-errored,
+   history-matched transfer → concurrent/repeated `Fail()` +
+   `DeleteTransfer()`.
+4. `countDownloads()` = `len(downloadList)/2` heuristic — miscounts for
+   multi-level folder trees.
+
+**Other risks:**
+
+- No graceful shutdown (no signal handling; `Run` blocks forever).
+- No config validation on `POST /api/config` (whole-struct replace; empty API
+  keys accepted).
+- CWD-relative `./static` serving (binary-install convention).
+- 1000-record history cap; full-scan fuzzy matching.
+- Aggressive log retention (100MB / 1 backup / 1 day).
+- `config.yaml` 0644 with plaintext keys; `GET /api/config` exposes all keys
+  (no auth by design — see decision 7).
+- `EnableTlsCheck=false` default (wget skips certificate verification).
+- EOL CI actions (`actions/checkout@v2`, `codeql-action@v2`); deb postinstall
+  uses BSD `sed -i ""` syntax (fails on Linux debs).
+- Stray `web/public/814.814.js` (+ LICENSE) chunk: copied into shipped static
+  but referenced by nothing.
+- Dead code (verifiably no internal callers; **removal not approved** without
+  public-API assessment — decision 8): `pkg/clouddownloader` (empty
+  interface), `utils.Unzip`, `utils.StringInSlice`,
+  `premiumizeme.GenerateZipped*` (legacy zip API), `service.Service`
+  interface (unimplemented).
+- `io/ioutil` usage throughout (deprecated since Go 1.16).
+
+## Roadmap candidates (each requires HITL; none pre-approved)
+
+- Built-in authentication.
+- Native Go downloader replacing wget.
+- Dead-code removal after public-API assessment.
+- ldflags version injection (single source of truth for the version string).
+- Node 24; ubuntu-24.x runner; Svelte 5 (open renovate branches).
+- Field-level validation for `POST /api/config`.
+- Secret hygiene: config file permissions (e.g. 0600), no-secrets-in-logs,
+  dangerous-defaults review — each proposed separately.
+- Graceful shutdown / signal handling.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,167 @@
+# PROJECT.md — Premiumizearr-Nova Project Contract
+
+Durable project contract: goals, scope, change policy, acceptance criteria.
+For the current architecture, component boundaries, and approved technical
+decisions, see `ARCHITECTURE.md`. For agent operating instructions, see
+`QWEN.md`.
+
+## What this project is
+
+Premiumizearr-Nova is a Go daemon (`premiumizearrd`) that bridges
+[premiumize.me](https://www.premiumize.me) to *arr media managers (Sonarr,
+Radarr, Lidarr):
+
+- Monitors a blackhole directory for `.nzb`, `.magnet`, and `.torrent` files
+  dropped by *arr clients (blackhole download clients) and pushes them to
+  premiumize.me.
+- Monitors and downloads completed premiumize.me transfers to a local downloads
+  directory (or runs in transfer-only mode).
+- Marks failed transfers in the *arr history.
+- Serves a web UI + JSON API (default port 8182) for status and configuration.
+
+It is a continuation of Jackdallas' Premiumizearr, licensed under GNU GPL v3.
+
+## Goals
+
+1. Reliable transfer pipeline: no lost blackhole files, no orphaned or
+   incomplete downloads, no download lockups.
+2. Maintained deployments: the Docker image is the primary, supported method;
+   binary/deb/Windows artifacts are built but documented as unsupported.
+3. A working web UI and API for status and configuration.
+4. A deterministic verification gate (`scripts/verify`) that is green and
+   enforced as a required CI check.
+
+## Out of current scope (roadmap candidates requiring HITL)
+
+These are **not** permanent product non-goals. Each requires explicit human
+planning/approval before work begins:
+
+- **Built-in authentication.** Out of current scope; the current approved
+  security model is an authenticated reverse proxy / trusted network boundary
+  (the service exposes API keys and has no authentication by design). Built-in
+  auth is a roadmap candidate requiring HITL.
+- Net-new product features without an approved objective, GitHub issue, or
+  approved planning decision. Agents must not invent product features.
+- Major dependency upgrades (including changes to the Go `go` directive, Node
+  24, Svelte major versions, *arr client library changes).
+- Architecture changes (service boundaries, config propagation, state model).
+- Security-model changes (authentication, secret storage) and persistence
+  changes (today: `config.yaml` + in-memory runtime state only).
+- New release targets or platforms.
+- Replacing the `wget`-based downloader with a native Go implementation.
+
+## Change policy
+
+Autonomous (agent) work is limited to:
+
+- **Bug fixes** — every bug fix must add a failing-first regression test where
+  reasonably feasible. If deterministic reproduction is not reasonably feasible,
+  document why and provide the strongest deterministic verification available.
+- **Behavior-preserving maintenance/hygiene** — formatting, vet defects, test
+  infrastructure, toolchain alignment, verification/CI.
+- **Test and verification improvements.**
+
+Explicit human (HITL) planning/approval is required for:
+
+- Major dependency upgrades; changes to the Go `go` directive; architecture
+  changes.
+- Breaking API/UI/CLI behavior changes.
+- Security-model or persistence changes.
+- Changes to this contract (`PROJECT.md`, `ARCHITECTURE.md`, `QWEN.md`,
+  `.qwen/review-rules.md`, `scripts/verify`, `.github/workflows/verify.yml`).
+- Removal or breaking change of exported symbols under `pkg/` — this is a
+  **public Go module**; external consumers may exist. Lack of internal callers
+  is not sufficient justification.
+
+Invariants:
+
+- Do not modify product source files merely to make `scripts/verify` green.
+- No suppressions, no `-vet=off`, no exclusions, no weakened checks — the gate
+  must not be weakened to make anything pass.
+- Net-new product behavior must originate from an approved objective, GitHub
+  issue, or approved planning decision.
+
+## Toolchain policy
+
+- `go.mod` intentionally declares `go 1.23.0` (minimum project floor) and
+  `toolchain go1.24.2` (the project Go toolchain). Development, CI
+  (`setup-go 1.24.2`), and verification all run on Go 1.24.2. Do not rewrite
+  `go.mod` or raise the go directive merely to align numbers; a floor change
+  is an explicit future maintenance decision (HITL).
+- Node standard: **22**. Pinned explicitly wherever the toolchain is used (CI
+  via `actions/setup-node`); never rely on runner preinstalled defaults. A move
+  to Node 24 is normal maintenance, decided later.
+- `scripts/verify` exports `GOTOOLCHAIN=local` and requires the locally
+  provisioned Go to be >= 1.24.2; it never downloads or installs toolchains.
+
+## Verification
+
+`scripts/verify` (repo root) is the single deterministic verification entry
+point and is mirrored by CI (`.github/workflows/verify.yml`). Gate details:
+`ARCHITECTURE.md` → "scripts/verify (the gate)".
+
+### Current gate state
+
+`scripts/verify` is **red by design** on the `planning/project-contract`
+branch: pre-existing gofmt/vet debt fails check 1 (gofmt). This is intentional
+and must not be "fixed" by weakening the gate. The red state ends with the
+baseline-cleanup task below.
+
+## Pilot acceptance criteria (this task: contract + verification setup)
+
+1. All 6 paths in place: `PROJECT.md`, `ARCHITECTURE.md`, `QWEN.md`,
+   `.qwen/review-rules.md`, `scripts/verify`, `.github/workflows/verify.yml`.
+2. `scripts/verify` implemented strictly per the gate spec and failing at the
+   gofmt stage on this branch (proof it catches the pre-existing debt).
+3. The PR verify job in place, running the same gate, red for the same
+   expected reason.
+4. Zero modifications to existing product source files on this branch.
+
+## Next explicit task: baseline cleanup
+
+Defined here; executed later as its own task/PR after this contract setup is
+reviewed. **Not part of this branch.**
+
+- gofmt the 15 currently non-clean Go files (mechanical).
+- Triage and fix each `go vet ./...` finding **individually** per its intended
+  behavior — not blanket-mechanical.
+- Add regression tests where a finding reveals or fixes meaningful behavior.
+- Add minimal test infrastructure as needed (httptest fakes for
+  premiumize.me/*arr, `t.TempDir`, no network).
+- **No** suppressions, `-vet=off`, exclusions, or weakened checks.
+- Small reviewable commits.
+- Exit criterion: `scripts/verify` green locally and in CI. Once that PR makes
+  verify green, mark the verify check a **required merge check**.
+
+## Follow-up backlog (priority selection deferred — needs explicit approval)
+
+**CI hygiene (existing workflows):**
+
+- Explicit `setup-node` (Node 22) in the release `build.yml` (today it relies
+  on the runner preinstalled Node).
+- EOL action pins: `actions/checkout@v2`, `codeql-action@v2`,
+  `github-script@v5`, `goreleaser-action@v2`.
+- ubuntu-24.x runner (open renovate branch).
+- Optional `push: main` trigger for the verify job (post-green).
+
+**Verified bug inventory (details: `ARCHITECTURE.md` → Known risks):**
+
+1. Stranded blackhole files on non-"already uploaded" transfer-create errors
+   (incl. limit-reached) + exact-string `err.Error()` matching.
+2. Data races: shared `*config.Config` mutated by the config API while poll
+   loops read it; unlocked status-field writes; web server `Close()`+`Start()`
+   from a handler goroutine (global `indexBytes`).
+3. `HandleErrorTransfer` spawned as a fresh goroutine every 15s per errored,
+   history-matched transfer (concurrent/repeated `Fail()` +
+   `DeleteTransfer()`).
+4. `countDownloads()` `len/2` heuristic miscounts for multi-level trees.
+
+## Deployment & operations notes
+
+- Docker is the recommended deployment (see README). The service has **no
+  authentication**: keep it behind an authenticated reverse proxy / trusted
+  network; bind to `127.0.0.1` where possible.
+- Runtime external dependencies: `wget` + `stdbuf` host binaries (installed in
+  the Docker image), premiumize.me API, *arr APIs.
+- State: `config.yaml` only. All runtime state (downloads in flight, failure
+  cooldowns, transfer cache) is in-memory and lost on restart.

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,55 @@
+# QWEN.md — Qwen operating instructions
+
+Read `PROJECT.md` (goals, scope, change policy) and `ARCHITECTURE.md`
+(architecture, approved decisions, gate details) before any work. They are
+authoritative; this file is a concise operating checklist.
+
+## Verification
+
+- `scripts/verify` (repo root) is the single mandatory verification gate. Run
+  it after any change; do not land a change that makes it worse.
+- The gate is currently **red by design** (pre-existing gofmt/vet debt — see
+  PROJECT.md → "Current gate state"). Do not weaken the gate, use `-vet=off`,
+  add suppressions/exclusions, or edit product source files merely to turn it
+  green. Gate failures are reported, not silently fixed.
+- Do not modify `scripts/verify`, `.github/workflows/verify.yml`, or the
+  contract documents without explicit human approval (contract changes
+  require HITL).
+
+## Change policy (summary)
+
+- Autonomous work: bug fixes (failing-first regression test where reasonably
+  feasible), behavior-preserving hygiene, test/verification improvements.
+- HITL required: major dependencies / the Go `go` directive, architecture
+  changes, breaking API/UI/CLI changes, security model, persistence, contract
+  changes, removal or breaking change of `pkg/` exports (public Go module),
+  net-new product features (must originate from an approved objective/issue).
+- Race fixes: minimal local synchronization only — reproduce →
+  `go test -race` → narrow fix; no unrelated concurrency refactoring in the
+  same change; no restructuring of config propagation or service boundaries.
+
+## Tests
+
+- Every bug fix must add a failing-first regression test where reasonably
+  feasible. If deterministic reproduction is not reasonably feasible, document
+  why and provide the strongest deterministic verification available.
+- Tests must be deterministic: `httptest` fakes for premiumize.me/*arr HTTP,
+  `t.TempDir` for filesystem, no network, no reliance on real config or host
+  binaries.
+- No coverage floor; test meaningful behavior.
+
+## Environment expectations
+
+- Locally provisioned Go >= 1.24.2 (verification runs with `GOTOOLCHAIN=local`;
+  go.mod keeps floor `go 1.23.0` / `toolchain go1.24.2`); Node 22; npm; a C
+  compiler (for `-race`).
+- `scripts/verify` checks all of the above and fails with actionable errors;
+  it never installs toolchains and never rewrites `go.mod`. If a prerequisite
+  is missing on this machine, report it — do not silently skip.
+
+## Repository notes
+
+- Keep contract/verification work (this branch) separate from product code
+  work; baseline cleanup is the next task, defined in PROJECT.md — it is a
+  distinct task, not part of the contract branch.
+- Commit style: imperative, concise (see `git log`).

--- a/scripts/verify
+++ b/scripts/verify
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# scripts/verify — deterministic local verification gate for Premiumizearr-Nova.
+#
+# Single mandatory entry point; CI mirrors it in .github/workflows/verify.yml.
+# Contract: PROJECT.md / ARCHITECTURE.md ("scripts/verify (the gate)").
+#
+# Rules enforced here:
+#   - never skip a mandatory check;
+#   - never download/install toolchains (GOTOOLCHAIN=local; npm dependencies
+#     are the only downloads);
+#   - never modify go.mod or product source to satisfy a check;
+#   - fail with an actionable message on the first failing check.
+
+set -euo pipefail
+
+# --- Anchor to repository root (this script lives in <root>/scripts). -------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT_DIR}"
+
+fail() {
+  echo ""
+  echo "VERIFY: FAILED — $*"
+  echo "        Fix the failing check, then re-run: bash scripts/verify"
+  exit 1
+}
+
+step() {
+  echo ""
+  echo "=== verify: $*"
+}
+
+# --- Preflight: required tools and versions ---------------------------------
+
+step "Preflight: required tools"
+
+# Go: verification always runs on the locally provisioned toolchain and never
+# downloads one: GOTOOLCHAIN=local is exported before any go invocation.
+# go.mod is intentionally left as-is:
+#   go 1.23.0        (minimum project floor)
+#   toolchain go1.24.2 (project toolchain; dev/CI provision it explicitly)
+# so the gate requires the local go to be >= 1.24.2. We never edit go.mod to
+# make this pass.
+if ! command -v go >/dev/null 2>&1; then
+  fail "go command not found. Install Go >= 1.24.2 (verification uses the locally provisioned toolchain via GOTOOLCHAIN=local)."
+fi
+
+export GOTOOLCHAIN=local
+echo "go command on PATH:      $(go version)"
+echo "GOTOOLCHAIN:             local (pinned by this script)"
+
+LOCAL_GO="$(go env GOVERSION 2>/dev/null)" || fail \
+  "go could not report its version (go env GOVERSION failed)."
+if ! printf '%s\n%s\n' "1.24.2" "${LOCAL_GO#go}" | sort -V -C; then
+  fail "local Go ${LOCAL_GO} is older than 1.24.2. Verification uses the locally provisioned toolchain (GOTOOLCHAIN=local) and never downloads one; install Go >= 1.24.2 (go.mod 'go 1.23.0' / 'toolchain go1.24.2' stays as-is)."
+fi
+
+# Node: project standard is Node 22 (ARCHITECTURE.md, approved decision 1).
+if ! command -v node >/dev/null 2>&1; then
+  fail "node not found. The project standard is Node 22 (e.g. install via nvm: 'nvm install 22 && nvm use 22')."
+fi
+NODE_VERSION="$(node -p 'process.versions.node')"
+NODE_MAJOR="${NODE_VERSION%%.*}"
+echo "node:                    ${NODE_VERSION}"
+if [[ "${NODE_MAJOR}" != "22" ]]; then
+  fail "Node ${NODE_VERSION} found; the project standard is Node 22. Install/activate Node 22 (e.g. 'nvm install 22 && nvm use 22')."
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  fail "npm not found. Install it together with Node 22."
+fi
+echo "npm:                     $(npm --version)"
+
+# C compiler: required by 'go test -race' (the race detector links via cgo).
+CC_BIN="$(command -v cc 2>/dev/null || command -v gcc 2>/dev/null || command -v clang 2>/dev/null || true)"
+if [[ -z "${CC_BIN}" ]]; then
+  fail "no C compiler found (cc/gcc/clang). 'go test -race' requires a C toolchain (e.g. 'apt-get install gcc')."
+fi
+echo "C compiler:              ${CC_BIN}"
+
+# --- Mandatory checks (the gate fails on the first failure) ------------------
+
+step "Check 1/6: gofmt clean (tracked Go files)"
+UNFORMATTED="$(git ls-files -z '*.go' | xargs -0 -r gofmt -l)"
+if [[ -n "${UNFORMATTED}" ]]; then
+  printf '%s\n' "${UNFORMATTED}" | sed 's/^/    /'
+  fail "tracked Go files are not gofmt-clean. Run 'gofmt -w' on them (baseline-cleanup task, see PROJECT.md)."
+fi
+echo "all tracked Go files gofmt-clean"
+
+step "Check 2/6: go vet"
+if ! go vet ./...; then
+  fail "go vet ./... reported findings. Fix them per their intended behavior; no suppressions or -vet=off (see PROJECT.md)."
+fi
+
+step "Check 3/6: production-style Go build"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+if ! CGO_ENABLED=0 go build -tags 'netgo osusergo' -ldflags '-extldflags "-static"' -o "${BUILD_DIR}/premiumizearrd" ./cmd/premiumizearrd; then
+  fail "production-style build failed (CGO_ENABLED=0, tags 'netgo osusergo', static)."
+fi
+echo "built ${BUILD_DIR}/premiumizearrd"
+
+step "Check 4/6: go test -race"
+if ! go test -race ./...; then
+  fail "go test -race ./... failed."
+fi
+
+step "Check 5/6: web dependencies (npm ci, locked graph)"
+if ! (cd web && npm ci); then
+  fail "npm ci failed in web/ (package-lock.json must be in sync with package.json)."
+fi
+
+step "Check 6/6: web production build"
+if ! (cd web && npm run build); then
+  fail "web production build failed (npm run build)."
+fi
+
+echo ""
+echo "VERIFY: PASS — all checks green"


### PR DESCRIPTION
## Summary

Establishes the durable project contract and deterministic verification infrastructure for Premiumizearr-Nova.

Adds:

- `PROJECT.md`
- `ARCHITECTURE.md`
- `QWEN.md`
- `.qwen/review-rules.md`
- `scripts/verify`
- `.github/workflows/verify.yml`

## Verification

`bash scripts/verify` is intentionally red on this PR.

Environment preflight passes with:

- Go 1.24.2
- Node 22.23.2
- npm 10.9.8
- C compiler available

The gate then fails at check 1/6 because of the 15 pre-existing non-gofmt-clean Go files.

This branch intentionally does not modify product source code or baseline debt.

## Next step

Baseline cleanup will be performed as a separate task/PR. Its exit criterion is a fully green `scripts/verify` locally and in CI.