### PR TITLE
docs: sync contract docs with post-baseline-cleanup state

### DIFF
--- a/.qwen/review-rules.md
+++ b/.qwen/review-rules.md
@@ -19,9 +19,8 @@ require explicit human approval).
 
 - No `-vet=off`, no vet suppressions, no nolint-style comments, no exclusions,
   no weakened checks — in code or in the gate.
-- No product-source edits whose only purpose is to make the gate green (while
-  the gate is intentionally red, gate failures are reported, not silently
-  "fixed").
+- No product-source edits whose only purpose is to make the gate green (gate
+  failures are reported, not silently "fixed").
 - No API keys or other secrets in logs, error messages, or test fixtures
   (premiumize.me key, *arr keys); request URLs that embed keys must not be
   logged.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,7 +135,9 @@ serves the SPA from ./static + JSON API. No authentication by design.
   base, s6), manifests.
 - CI: `build.yml` (release/snapshot via goreleaser on tags/PRs) — **separate
   from the verify job**.
-- New: `verify.yml` — PR-triggered, runs `scripts/verify` (below).
+- `verify.yml` — PR-triggered, runs `scripts/verify` (below); the
+  `verify (scripts/verify)` check is a required merge check on `main`
+  (rule set `main-quality-gate`).
 - Version 1.5.1 is hardcoded manually (banner in `main.go`, README, git tag).
 
 ## Approved technical decisions
@@ -153,7 +155,8 @@ serves the SPA from ./static + JSON API. No authentication by design.
    below. Never weakened.
 4. **Baseline policy:** one-time behavior-preserving cleanup task (defined in
    PROJECT.md) brings the gate green; no suppressions, no `-vet=off`, no
-   exclusions, no weakened checks.
+   exclusions, no weakened checks. **Executed:** completed in PR #71
+   (merged 2026-08-28); the gate has been green since.
 5. **Race remediation policy:** minimal local synchronization (mutex/atomic/
    safe snapshot) preserving architecture and observable behavior; treat
    races as individual bugs (reproduce → `go test -race` test → narrow fix).
@@ -164,12 +167,12 @@ serves the SPA from ./static + JSON API. No authentication by design.
    proxy / trusted network.
 8. **`pkg/` is the public Go module API surface:** no removal/breaking change
    of exported symbols without a public-API assessment (HITL).
-9. **CI verify job:** `pull_request`-triggered only for now (no push-to-main
-   trigger while the gate is intentionally red pending baseline cleanup).
-   After the baseline-cleanup PR makes verify green, mark it a required merge
-   check; a push-to-main trigger can be added later if useful. The
-   release/Goreleaser workflow stays separate and is untouched by the verify
-   work.
+9. **CI verify job:** `pull_request`-triggered; the
+   `verify (scripts/verify)` check is a **required merge check** on `main`
+   (rule set `main-quality-gate`, added once the baseline-cleanup PR made
+   verify green). A `push: main` trigger can be added later if useful
+   (not yet added). The release/Goreleaser workflow stays separate and is
+   untouched by the verify work.
 
 ## scripts/verify (the gate)
 
@@ -199,8 +202,10 @@ checks; never downloads or installs toolchains (verification exports
 5. `cd web && npm ci` (locked dependency graph).
 6. `cd web && npm run build` (production webpack build).
 
-**Gate state:** red on `planning/project-contract` by design (pre-existing
-gofmt/vet debt at check 1); do not weaken.
+**Gate state:** green (the pre-existing gofmt/vet debt that failed check 1 on
+the original `planning/project-contract` branch was removed by the baseline
+cleanup, PR #71); enforced as a required merge check on `main`; do not
+weaken.
 
 ## Known risks & limitations (verified, not yet fixed)
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -102,36 +102,43 @@ point and is mirrored by CI (`.github/workflows/verify.yml`). Gate details:
 
 ### Current gate state
 
-`scripts/verify` is **red by design** on the `planning/project-contract`
-branch: pre-existing gofmt/vet debt fails check 1 (gofmt). This is intentional
-and must not be "fixed" by weakening the gate. The red state ends with the
-baseline-cleanup task below.
+`scripts/verify` is **green**: the baseline cleanup (completed — see the
+historical section below) removed the pre-existing gofmt/vet debt, and the
+gate has been passing locally and in CI since. The `verify (scripts/verify)`
+check is enforced as a **required merge check** on `main` (repo rule set
+`main-quality-gate`). Do not weaken the gate or edit product source files
+merely to keep it green.
 
-## Pilot acceptance criteria (this task: contract + verification setup)
+## Historical: pilot acceptance criteria (contract + verification setup, PR #70, merged 2026-08-27)
+
+The pilot task is complete; the criteria below are recorded as history, not
+current requirements. At the time, the gate was intentionally red on the
+contract branch to prove it caught the pre-existing gofmt/vet debt.
 
 1. All 6 paths in place: `PROJECT.md`, `ARCHITECTURE.md`, `QWEN.md`,
    `.qwen/review-rules.md`, `scripts/verify`, `.github/workflows/verify.yml`.
 2. `scripts/verify` implemented strictly per the gate spec and failing at the
-   gofmt stage on this branch (proof it catches the pre-existing debt).
+   gofmt stage on that branch (proof it caught the pre-existing debt).
 3. The PR verify job in place, running the same gate, red for the same
    expected reason.
-4. Zero modifications to existing product source files on this branch.
+4. Zero modifications to existing product source files on that branch.
 
-## Next explicit task: baseline cleanup
+## Historical: baseline cleanup (completed, PR #71, merged 2026-08-28)
 
-Defined here; executed later as its own task/PR after this contract setup is
-reviewed. **Not part of this branch.**
+The baseline-cleanup task is **complete**; this section is recorded as
+history, not a pending task. It ran as its own PR on its own branch after the
+contract setup was reviewed:
 
-- gofmt the 15 currently non-clean Go files (mechanical).
-- Triage and fix each `go vet ./...` finding **individually** per its intended
-  behavior — not blanket-mechanical.
-- Add regression tests where a finding reveals or fixes meaningful behavior.
-- Add minimal test infrastructure as needed (httptest fakes for
+- gofmt'd the then-non-clean Go files (mechanical).
+- Triaged and fixed each `go vet ./...` finding **individually** per its
+  intended behavior — not blanket-mechanical.
+- Added regression tests where a finding revealed or fixed meaningful
+  behavior, plus minimal test infrastructure as needed (httptest fakes for
   premiumize.me/*arr, `t.TempDir`, no network).
 - **No** suppressions, `-vet=off`, exclusions, or weakened checks.
-- Small reviewable commits.
-- Exit criterion: `scripts/verify` green locally and in CI. Once that PR makes
-  verify green, mark the verify check a **required merge check**.
+- Exit criteria met: `scripts/verify` green locally and in CI; the
+  `verify (scripts/verify)` check was then marked a **required merge check**
+  on `main` (rule set `main-quality-gate`).
 
 ## Follow-up backlog (priority selection deferred — needs explicit approval)
 
@@ -142,7 +149,8 @@ reviewed. **Not part of this branch.**
 - EOL action pins: `actions/checkout@v2`, `codeql-action@v2`,
   `github-script@v5`, `goreleaser-action@v2`.
 - ubuntu-24.x runner (open renovate branch).
-- Optional `push: main` trigger for the verify job (post-green).
+- Optional `push: main` trigger for the verify job (gate is green, so this
+  is no longer blocked on anything; still not added).
 
 **Verified bug inventory (details: `ARCHITECTURE.md` → Known risks):**
 

--- a/QWEN.md
+++ b/QWEN.md
@@ -8,10 +8,11 @@ authoritative; this file is a concise operating checklist.
 
 - `scripts/verify` (repo root) is the single mandatory verification gate. Run
   it after any change; do not land a change that makes it worse.
-- The gate is currently **red by design** (pre-existing gofmt/vet debt — see
-  PROJECT.md → "Current gate state"). Do not weaken the gate, use `-vet=off`,
-  add suppressions/exclusions, or edit product source files merely to turn it
-  green. Gate failures are reported, not silently fixed.
+- The gate is currently **green** (the baseline cleanup removed the
+  pre-existing gofmt/vet debt — see PROJECT.md → "Current gate state"). Do
+  not weaken the gate, use `-vet=off`, add suppressions/exclusions, or edit
+  product source files merely to keep it green. Gate failures are reported,
+  not silently fixed.
 - Do not modify `scripts/verify`, `.github/workflows/verify.yml`, or the
   contract documents without explicit human approval (contract changes
   require HITL).
@@ -49,7 +50,7 @@ authoritative; this file is a concise operating checklist.
 
 ## Repository notes
 
-- Keep contract/verification work (this branch) separate from product code
-  work; baseline cleanup is the next task, defined in PROJECT.md — it is a
-  distinct task, not part of the contract branch.
+- Keep contract/verification work separate from product code work in its own
+  branch/PR (the contract setup and baseline-cleanup tasks followed this
+  pattern and are complete — see PROJECT.md).
 - Commit style: imperative, concise (see `git log`).


### PR DESCRIPTION
## Summary

Synchronizes the project contract and agent-instruction files with the repository's actual post-baseline-cleanup state. **Documentation only — no product code or verification behavior changed** (`scripts/verify` and `.github/workflows/verify.yml` are untouched).

## Stale statements corrected

- **PROJECT.md → "Current gate state"**: said `scripts/verify` is "red by design" with the red state ending with the baseline-cleanup task. Now states the gate is **green** (baseline cleanup completed) and that `verify (scripts/verify)` is enforced as a **required merge check** on `main` (ruleset `main-quality-gate`).
- **PROJECT.md → "Pilot acceptance criteria"**: retitled and relabeled as **historical** (PR #70, merged 2026-08-27); "on this branch" → "on that branch", past tense, with an explicit note that the criteria are history, not current requirements.
- **PROJECT.md → "Next explicit task: baseline cleanup"**: retitled to **Historical: baseline cleanup (completed, PR #71, merged 2026-08-28)**; rewritten in past tense, exit criteria marked as met (gate green; verify marked a required merge check).
- **PROJECT.md → follow-up backlog**: removed the stale "(post-green)" qualifier on the optional `push: main` trigger item (the gate is green, so it is no longer blocked on anything).
- **ARCHITECTURE.md → Build/release/CI**: "New: verify.yml" → states the verify check is a required merge check on `main`.
- **ARCHITECTURE.md → decision 4 (Baseline policy)**: marked **Executed** (PR #71; gate green since).
- **ARCHITECTURE.md → decision 9 (CI verify job)**: removed "no push-to-main trigger while the gate is intentionally red pending baseline cleanup" and "after the baseline-cleanup PR makes verify green, mark it a required merge check"; now states verify is a required merge check (ruleset `main-quality-gate`) and the `push: main` trigger remains optional/not yet added.
- **ARCHITECTURE.md → scripts/verify "Gate state"**: "red on planning/project-contract by design" → **green** (pre-existing gofmt/vet debt removed by PR #71), enforced as a required merge check on `main`.
- **QWEN.md → Verification**: "gate is currently red by design" → "gate is currently **green**".
- **QWEN.md → Repository notes**: "baseline cleanup is the next task" → contract setup and baseline-cleanup tasks noted as complete.
- **.qwen/review-rules.md → Prohibitions**: removed the stale "(while the gate is intentionally red …)" parenthetical; the prohibition itself is unchanged.

## Verified

- `bash scripts/verify` passes after the changes: `VERIFY: PASS — all checks green` (all 6 checks + preflight).
- The four files were cross-checked for contradictions: goals, change policy, HITL boundaries, verification requirements, and review invariants are preserved and consistent across all files.

## Risks / follow-ups

- None. The stale comment inside `.github/workflows/verify.yml` ("intentionally red until the baseline-cleanup task") was intentionally left as-is per scope (workflow changes out of scope for this sync).