### PR TITLE
docs: add AO tracker-intake canary note to PROJECT.md

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,3 +1,5 @@
+<!-- AO tracker-intake canary: issue github:ensingerphilipp/Premiumizearr-Nova#74 was used to qualify AO tracker intake. -->
+
 # PROJECT.md — Premiumizearr-Nova Project Contract
 
 Durable project contract: goals, scope, change policy, acceptance criteria.


### PR DESCRIPTION
## Summary

AO tracker-intake qualification (canary) task. Makes one harmless,
documentation-only change: adds a short HTML comment to `PROJECT.md`
stating that issue #74 was used to qualify AO tracker intake.

Closes #74

## Change

- `PROJECT.md`: one-line HTML comment at the top of the file.

## Verification

- `scripts/verify` — PASS (all 6 checks green: gofmt, go vet, build,
  `go test -race`, web dependency install, web production build).

## Risks / follow-ups

- None. No product code, dependencies, `scripts/verify`, or CI
  configuration modified.