### PR TITLE
docs: define publication-policy required CI as deterministic checks

### DIFF
--- a/docs/ao/github-semantic-review-publication.md
+++ b/docs/ao/github-semantic-review-publication.md
@@ -39,7 +39,7 @@ Use the canonical PR URL as the target URL.
 
 Before creating a status, read the current status for this context. If its state, description, and target URL already equal the desired values, do nothing.
 
-After dispatch has passed the normal readiness, exact-head, and required-CI checks, publish:
+After dispatch has passed the normal readiness, exact-head, and required DETERMINISTIC CI checks (required checks excluding only the exact context `ao/semantic-review`), publish:
 
 * State: `pending`
 * Description: `AO semantic review running for <SHORT_SHA>`
@@ -83,7 +83,7 @@ It must concisely include:
 * Requested and selected effort
 * Selection reasons when available
 * Native and base events
-* Required-CI result
+* Required DETERMINISTIC CI result (required checks excluding only the exact context `ao/semantic-review`)
 * Semantic disposition
 * Every finding, including informational and non-blocking findings
 * For each finding: stable ID, severity, confidence, summary, and source location
@@ -112,7 +112,7 @@ A publication failure does not invalidate a trustworthy local semantic result. R
 
 For each qualified exact-SHA review:
 
-1. Validate readiness, required CI, repository identity, PR identity, and expected head.
+1. Validate readiness, required DETERMINISTIC CI (required checks excluding only the exact context `ao/semantic-review`), repository identity, PR identity, and expected head.
 2. Dispatch exactly one `ao-pr-review` invocation.
 3. Publish or retain the idempotent `pending` status and `RUNNING` summary.
 4. Monitor without busy polling.


### PR DESCRIPTION
## What changed

`docs/ao/github-semantic-review-publication.md` now defines every "required CI" reference as required **deterministic** checks — required checks excluding ONLY the exact context `ao/semantic-review`:

- GitHub status section: "After dispatch has passed the normal readiness, exact-head, and required DETERMINISTIC CI checks (required checks excluding only the exact context `ao/semantic-review`), publish:"
- Pull-request summary bullet: "Required DETERMINISTIC CI result (required checks excluding only the exact context `ao/semantic-review`)"
- Lifecycle step 1: "Validate readiness, required DETERMINISTIC CI (required checks excluding only the exact context `ao/semantic-review`), repository identity, PR identity, and expected head."

Nothing else in the document changed: markers, status context, states, descriptions, exact-SHA binding, the single marked summary comment, and all other rules remain verbatim.

## Why

`ao/semantic-review` is the commit status the AO orchestrator publishes *after* each semantic review. If the policy's "required CI" includes that context, the pipeline self-blocks: dispatch requires the semantic check to pass, but only a review can pass it. This wording change makes "required CI before review" mean all required deterministic checks, excluding only the exact context `ao/semantic-review`. It pairs with the host-global `ao-pr-review` v0.2.6 skill (same exclusion in the helper's preflight) and the project's AO agentRules/orchestratorRules.

## Follow-up

Making `ao/semantic-review` a GitHub **required check** via the ruleset/branch protection is a deliberate **follow-up** to be done after real publication qualification — intentionally not part of this PR. Merge is manual; no ruleset or branch-protection changes are made here.

## Verification

- `bash scripts/verify`: PASS (gate state unchanged; docs-only change)