### PR TITLE
docs: fix systemctl command in binary install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cd Premiumizearr_x.x.x.x_linux_amd64
 sudo mkdir /opt/premiumizearrd/
 sudo cp -r premiumizearrd static/ /opt/premiumizearrd/
 sudo cp premiumizearrd.service /etc/systemd/system/
-sudo systemctl-reload
+sudo systemctl daemon-reload
 sudo systemctl enable premiumizearrd.service
 sudo systemctl start premiumizearrd.service
 ```


### PR DESCRIPTION
## Summary

Documentation-only fix for the README "Binary → System Install" instructions:
`sudo systemctl-reload` is not a valid command, so following the README fails
at that step. This changes it to `sudo systemctl daemon-reload`, matching what
`scripts/postinstall.sh` already uses. No product behavior is affected.

Fixes #85

## Tests

- `bash scripts/verify`: pass — all checks green (gofmt, go vet, static build,
  `go test -race`, `npm ci`, `npm run build`)

## Risks / follow-ups

None — README only.