### PR TITLE
Redact API transport errors and retry stranded blackhole uploads

### DIFF
--- a/internal/service/directory_watcher_service.go
+++ b/internal/service/directory_watcher_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -65,6 +66,8 @@ func (dw *DirectoryWatcherService) ConfigUpdatedCallback(currentConfig config.Co
 }
 
 func (dw *DirectoryWatcherService) GetStatus() string {
+	dw.mu.RLock()
+	defer dw.mu.RUnlock()
 	return dw.status
 }
 
@@ -157,7 +160,9 @@ func (dw *DirectoryWatcherService) checkFile(path string) int {
 }
 
 func (dw *DirectoryWatcherService) addFileToQueue(path string) {
-	dw.Queue.Add(path)
+	if !dw.Queue.AddIfAbsent(path) {
+		return
+	}
 	log.Infof("File created in blackhole %s added to Queue. Queue length %d", path, dw.Queue.Len())
 }
 
@@ -174,38 +179,46 @@ func (dw *DirectoryWatcherService) processUploads() {
 			continue
 		}
 
-		sleepTimeSeconds := 2
-		if filePath != "" {
-			log.Debugf("Processing %s", filePath)
-			dw.mu.RLock()
-			folderID := dw.downloadsFolderID
-			dw.mu.RUnlock()
-			err := dw.premiumizemeClient.CreateTransfer(filePath, folderID)
-			if err != nil {
-				switch err.Error() {
-				case ERROR_LIMIT_REACHED:
-					dw.status = "Limit of transfers reached!"
-					log.Trace("Transfer limit reached waiting 10 seconds and retrying")
-					sleepTimeSeconds = 10
-				case ERROR_ALREADY_UPLOADED:
-					log.Trace("File already uploaded, removing from Disk")
-					os.Remove(filePath)
-				default:
-					log.Errorf("Error creating transfer: %s", err)
-				}
-			} else {
-				dw.status = "Okay"
-				os.Remove(filePath)
-				if err != nil {
-					log.Errorf("Error could not delete %s Error: %+v", filePath, err)
-				}
-				log.Infof("Removed %s from blackhole Queue. Queue Size: %d", filePath, dw.Queue.Len())
-			}
-			time.Sleep(time.Second * time.Duration(sleepTimeSeconds))
-		} else {
-			log.Error("Received an empty path from blackhole Queue.")
+		if filePath == "" {
+			continue
 		}
+		time.Sleep(dw.processUpload(filePath))
 	}
+}
+
+// processUpload handles one queue entry and returns the delay before the next.
+func (dw *DirectoryWatcherService) processUpload(filePath string) time.Duration {
+	log.Debugf("Processing %s", filePath)
+	dw.mu.RLock()
+	folderID := dw.downloadsFolderID
+	dw.mu.RUnlock()
+	err := dw.premiumizemeClient.CreateTransfer(filePath, folderID)
+	if err != nil && !errors.Is(err, premiumizeme.ErrTransferAlreadyExists) {
+		// A removed file cannot be retried. Every other failure stays queued,
+		// including unfamiliar vendor messages and transient transport failures.
+		if errors.Is(err, os.ErrNotExist) {
+			return 2 * time.Second
+		}
+		dw.Queue.AddIfAbsent(filePath)
+		dw.mu.Lock()
+		if errors.Is(err, premiumizeme.ErrTransferLimitReached) {
+			dw.status = ERROR_LIMIT_REACHED
+		} else {
+			dw.status = "Transfer failed; retrying"
+		}
+		dw.mu.Unlock()
+		log.Warnf("Could not create transfer; retaining source and retrying in 10 seconds: %s", err)
+		return 10 * time.Second
+	}
+	// Success and already-existing jobs are both terminal.
+	if removeErr := os.Remove(filePath); removeErr != nil {
+		log.Errorf("Could not delete %s: %s", filePath, removeErr)
+	}
+	dw.mu.Lock()
+	dw.status = "Okay"
+	dw.mu.Unlock()
+	log.Infof("Removed %s from blackhole queue. Queue size: %d", filePath, dw.Queue.Len())
+	return 2 * time.Second
 }
 
 func (dw *DirectoryWatcherService) setTransferDirectory(newDir string) {

--- a/internal/service/directory_watcher_service_test.go
+++ b/internal/service/directory_watcher_service_test.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ensingerphilipp/premiumizearr-nova/pkg/premiumizeme"
+	"github.com/ensingerphilipp/premiumizearr-nova/pkg/stringqueue"
+	log "github.com/sirupsen/logrus"
+)
+
+type uploadTestTransport func(*http.Request) (*http.Response, error)
+
+func (f uploadTestTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestFailedUploadRetriesWithoutRescan(t *testing.T) {
+	for _, failure := range []string{"temporary backend failure", "Limit of transfers reached!", "account_limit_reached", "new provider limit wording"} {
+		t.Run(failure, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if calls.Add(1) == 1 {
+					w.Write([]byte(`{"status":"error","message":"` + failure + `"}`))
+					return
+				}
+				w.Write([]byte(`{"status":"success"}`))
+			}))
+			defer server.Close()
+			target, _ := url.Parse(server.URL)
+			original := http.DefaultTransport
+			http.DefaultTransport = uploadTestTransport(func(r *http.Request) (*http.Response, error) {
+				copy := r.Clone(r.Context())
+				copy.URL.Scheme = target.Scheme
+				copy.URL.Host = target.Host
+				return original.RoundTrip(copy)
+			})
+			defer func() { http.DefaultTransport = original }()
+			file := filepath.Join(t.TempDir(), "retry.magnet")
+			if err := os.WriteFile(file, []byte("magnet:?xt=urn:btih:test"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			client := premiumizeme.NewPremiumizemeClient("dummy-test-key")
+			svc := NewDirectoryWatcherService()
+			svc.Queue = stringqueue.NewStringQueue()
+			svc.premiumizemeClient = &client
+			// The processor has just popped this path. No watcher event/rescan follows.
+			if delay := svc.processUpload(file); delay < 10*time.Second {
+				t.Errorf("retry delay = %s", delay)
+			}
+			if _, err := os.Stat(file); err != nil {
+				t.Fatal("failed upload lost source")
+			}
+			ok, retry := svc.Queue.PopTopOfQueue()
+			if !ok || retry != file {
+				t.Fatal("failed upload was stranded outside queue")
+			}
+			if delay := svc.processUpload(retry); delay != 2*time.Second {
+				t.Fatalf("success delay = %s", delay)
+			}
+			if _, err := os.Stat(file); !os.IsNotExist(err) {
+				t.Fatal("successful upload retained source")
+			}
+			if svc.Queue.Len() != 0 || calls.Load() != 2 {
+				t.Fatal("unexpected retry count")
+			}
+		})
+	}
+}
+
+func TestPollingDoesNotDuplicateQueuedUploads(t *testing.T) {
+	svc := NewDirectoryWatcherService()
+	svc.Queue = stringqueue.NewStringQueue()
+	var logs bytes.Buffer
+	logger := log.StandardLogger()
+	old := logger.Out
+	logger.SetOutput(&logs)
+	defer logger.SetOutput(old)
+	svc.addFileToQueue("request.magnet")
+	svc.addFileToQueue("request.magnet")
+	if svc.Queue.Len() != 1 {
+		t.Fatal("polling added duplicate work")
+	}
+	if strings.Count(logs.String(), "added to Queue") != 1 {
+		t.Fatal("duplicate insertion logged")
+	}
+}
+
+func TestAlreadyUploadedSourceIsRemoved(t *testing.T) {
+	original := http.DefaultTransport
+	http.DefaultTransport = uploadTestTransport(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"status":"error","message":" YOU ALREADY ADDED THIS JOB! "}`)), Header: make(http.Header)}, nil
+	})
+	defer func() { http.DefaultTransport = original }()
+	file := filepath.Join(t.TempDir(), "duplicate.magnet")
+	if err := os.WriteFile(file, []byte("magnet:?xt=urn:btih:test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	pm := premiumizeme.NewPremiumizemeClient("dummy-key")
+	svc := NewDirectoryWatcherService()
+	svc.Queue = stringqueue.NewStringQueue()
+	svc.premiumizemeClient = &pm
+	if delay := svc.processUpload(file); delay != 2*time.Second {
+		t.Fatalf("terminal delay = %s", delay)
+	}
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Fatal("already-uploaded source retained")
+	}
+	if svc.Queue.Len() != 0 || svc.GetStatus() != "Okay" {
+		t.Fatal("terminal job queued for retry")
+	}
+}
+
+func TestRemovedSourceDoesNotRetry(t *testing.T) {
+	pm := premiumizeme.NewPremiumizemeClient("dummy-key")
+	svc := NewDirectoryWatcherService()
+	svc.Queue = stringqueue.NewStringQueue()
+	svc.premiumizemeClient = &pm
+	svc.processUpload(filepath.Join(t.TempDir(), "missing.magnet"))
+	if svc.Queue.Len() != 0 {
+		t.Fatal("missing source queued forever")
+	}
+}

--- a/pkg/premiumizeme/premiumizeme.go
+++ b/pkg/premiumizeme/premiumizeme.go
@@ -3,6 +3,7 @@ package premiumizeme
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -38,6 +39,52 @@ func (pm *Premiumizeme) createPremiumizemeURL(urlPath string) (url.URL, error) {
 	return *u, nil
 }
 
+// do keeps credential-bearing request URLs and transport errors out of
+// callers' logs. All API entry points use this boundary.
+func (pm *Premiumizeme) do(client *http.Client, request *http.Request) (*http.Response, error) {
+	response, err := client.Do(request)
+	if err != nil {
+		// Do not wrap the original error: url.Error retains the secret URL.
+		return response, errors.New(pm.redact(err.Error()))
+	}
+	return response, nil
+}
+
+func (pm *Premiumizeme) redact(message string) string {
+	for _, secret := range []string{url.QueryEscape(pm.APIKey), url.PathEscape(pm.APIKey), pm.APIKey} {
+		if secret != "" {
+			message = strings.ReplaceAll(message, secret, "[REDACTED]")
+		}
+	}
+	return message
+}
+
+// These classifications let callers handle wrapped errors without relying on
+// their displayed text. Unknown provider failures must remain retryable.
+var (
+	ErrTransferAlreadyExists = errors.New("You already added this job.")
+	ErrTransferLimitReached  = errors.New("Limit of transfers reached!")
+)
+
+type transferError struct {
+	message string
+	kind    error
+}
+
+func (e *transferError) Error() string        { return e.message }
+func (e *transferError) Is(target error) bool { return e.kind != nil && target == e.kind }
+
+func (pm *Premiumizeme) transferFailure(message string) error {
+	var kind error
+	switch strings.TrimRight(strings.ToLower(strings.TrimSpace(message)), ".!") {
+	case "you already added this job":
+		kind = ErrTransferAlreadyExists
+	case "limit of transfers reached", "account_limit_reached":
+		kind = ErrTransferLimitReached
+	}
+	return &transferError{message: pm.redact(message), kind: kind}
+}
+
 var (
 	ErrAPIKeyNotSet = fmt.Errorf("premiumize.me API key not set")
 )
@@ -56,7 +103,7 @@ func (pm *Premiumizeme) GetTransfers() ([]Transfer, error) {
 	var ret []Transfer
 	req, _ := http.NewRequest("GET", url.String(), nil)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := pm.do(http.DefaultClient, req)
 	if err != nil {
 		return ret, err
 	}
@@ -98,7 +145,7 @@ func (pm *Premiumizeme) ListFolder(folderID string) ([]Item, error) {
 		return ret, err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return ret, err
 	}
@@ -137,7 +184,7 @@ func (pm *Premiumizeme) GetFolders() ([]Item, error) {
 	var ret []Item
 	req, _ := http.NewRequest("GET", url.String(), nil)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := pm.do(http.DefaultClient, req)
 	if err != nil {
 		return ret, err
 	}
@@ -197,16 +244,17 @@ func (pm *Premiumizeme) CreateTransfer(filePath string, parentID string) error {
 		return err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return err
 	}
+
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("error creating transfer: %s (%d)", resp.Status, resp.StatusCode)
 	}
 
-	defer resp.Body.Close()
 	res := CreateTransferResponse{}
 	log.Trace("CreateTransfer: Reading response")
 	err = json.NewDecoder(resp.Body).Decode(&res)
@@ -216,7 +264,7 @@ func (pm *Premiumizeme) CreateTransfer(filePath string, parentID string) error {
 	}
 
 	if res.Status != "success" {
-		return fmt.Errorf(res.Message)
+		return pm.transferFailure(res.Message)
 	}
 
 	log.Tracef("Transfer created: %+v", res)
@@ -244,7 +292,7 @@ func (pm *Premiumizeme) DeleteFolder(folderID string) error {
 		return err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return err
 	}
@@ -292,7 +340,7 @@ func (pm *Premiumizeme) MoveItem(itemID string, folderID string) error {
 		return err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return err
 	}
@@ -342,7 +390,7 @@ func (pm *Premiumizeme) CreateFolder(folderName string, parentID *string) (strin
 		return "", err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return "", err
 	}
@@ -383,7 +431,7 @@ func (pm *Premiumizeme) DeleteTransfer(id string) error {
 		return err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return err
 	}
@@ -605,7 +653,7 @@ func (pm *Premiumizeme) generateZip(ID string, srcType SRCType) (string, error) 
 
 	//Fire request
 	client := &http.Client{}
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return "", err
 	}
@@ -657,7 +705,7 @@ func (pm *Premiumizeme) GenerateFileLink(ID string) (string, error) {
 		return "", err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := pm.do(client, request)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/premiumizeme/premiumizeme_test.go
+++ b/pkg/premiumizeme/premiumizeme_test.go
@@ -1,6 +1,8 @@
 package premiumizeme
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -108,4 +110,77 @@ func readMultipartFields(t *testing.T, req *http.Request) map[string]string {
 	}
 
 	return fields
+}
+
+func TestAPITransportErrorsRedactKeys(t *testing.T) {
+	key := "test secret/+"
+	client := NewPremiumizemeClient(key)
+	file := createTempTransferFile(t, ".magnet", "magnet:?xt=urn:btih:test")
+	file.Close()
+	old := http.DefaultTransport
+	http.DefaultTransport = reviewTransport(func(r *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("connection failed for %s (key %s)", r.URL, key)
+	})
+	defer func() { http.DefaultTransport = old }()
+	cases := map[string]func() error{
+		"transfer/create": func() error { return client.CreateTransfer(file.Name(), "folder") },
+		"transfer/list":   func() error { _, err := client.GetTransfers(); return err },
+		"folder/list":     func() error { _, err := client.ListFolder("folder"); return err },
+		"folders":         func() error { _, err := client.GetFolders(); return err },
+		"folder/delete":   func() error { return client.DeleteFolder("folder") },
+		"item/move":       func() error { return client.MoveItem("item", "folder") },
+		"folder/create":   func() error { _, err := client.CreateFolder("folder", nil); return err },
+		"transfer/delete": func() error { return client.DeleteTransfer("transfer") },
+		"zip/file":        func() error { _, err := client.GenerateZippedFileLink("file"); return err },
+		"zip/folder":      func() error { _, err := client.GenerateZippedFolderLink("folder"); return err },
+		"item/details":    func() error { _, err := client.GenerateFileLink("file"); return err },
+	}
+	for name, call := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil {
+				t.Fatal("expected transport error")
+			}
+			for _, format := range []string{"%s", "%v", "%+v", "%#v"} {
+				message := fmt.Sprintf(format, err)
+				for _, secret := range []string{key, url.QueryEscape(key), url.PathEscape(key)} {
+					if strings.Contains(message, secret) {
+						t.Errorf("error formatting %s exposes API key", format)
+					}
+				}
+			}
+		})
+	}
+}
+
+type reviewTransport func(*http.Request) (*http.Response, error)
+
+func (f reviewTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestTransferFailuresHaveStableClassification(t *testing.T) {
+	for _, test := range []struct {
+		message string
+		kind    error
+	}{
+		{"You already added this job.", ErrTransferAlreadyExists},
+		{" YOU ALREADY ADDED THIS JOB! ", ErrTransferAlreadyExists},
+		{"Limit of transfers reached!", ErrTransferLimitReached},
+		{"account_limit_reached", ErrTransferLimitReached},
+		{"unknown failure", nil},
+	} {
+		t.Run(test.message, func(t *testing.T) {
+			pm := NewPremiumizemeClient("dummy-key")
+			err := pm.transferFailure(test.message)
+			if err.Error() != test.message {
+				t.Fatal("displayed provider message changed")
+			}
+			wrapped := fmt.Errorf("upload failed: %w", err)
+			if test.kind != nil && !errors.Is(wrapped, test.kind) {
+				t.Fatal("wrapped error lost classification")
+			}
+			if test.kind == nil && (errors.Is(wrapped, ErrTransferAlreadyExists) || errors.Is(wrapped, ErrTransferLimitReached)) {
+				t.Fatal("unknown failure misclassified")
+			}
+		})
+	}
 }

--- a/pkg/stringqueue/stringqueue.go
+++ b/pkg/stringqueue/stringqueue.go
@@ -3,7 +3,7 @@ package stringqueue
 import "sync"
 
 func NewStringQueue() *StringQueue {
-	return &StringQueue{queue: make([]string, 0), mutex: &sync.Mutex{}}
+	return &StringQueue{queue: make([]string, 0), counts: make(map[string]int), mutex: &sync.Mutex{}}
 }
 
 func (UploadQueue *StringQueue) Len() int {
@@ -16,6 +16,20 @@ func (UploadQueue *StringQueue) Add(path string) {
 	UploadQueue.mutex.Lock()
 	defer UploadQueue.mutex.Unlock()
 	UploadQueue.queue = append(UploadQueue.queue, path)
+	UploadQueue.counts[path]++
+}
+
+// AddIfAbsent atomically queues a path only when it is not already waiting.
+// Add retains its existing append semantics for public-module callers.
+func (UploadQueue *StringQueue) AddIfAbsent(path string) bool {
+	UploadQueue.mutex.Lock()
+	defer UploadQueue.mutex.Unlock()
+	if UploadQueue.counts[path] > 0 {
+		return false
+	}
+	UploadQueue.queue = append(UploadQueue.queue, path)
+	UploadQueue.counts[path]++
+	return true
 }
 
 func (UploadQueue *StringQueue) PopTopOfQueue() (bool, string) {
@@ -23,14 +37,19 @@ func (UploadQueue *StringQueue) PopTopOfQueue() (bool, string) {
 	defer UploadQueue.mutex.Unlock()
 	if len(UploadQueue.queue) > 0 {
 		rtn := UploadQueue.queue[0]
+		UploadQueue.counts[rtn]--
+		if UploadQueue.counts[rtn] == 0 {
+			delete(UploadQueue.counts, rtn)
+		}
 		UploadQueue.queue = UploadQueue.queue[1:]
 		return true, rtn
 	}
 	return false, ""
 }
 
+// GetQueue returns a snapshot; callers cannot mutate queue membership.
 func (UploadQueue *StringQueue) GetQueue() []string {
 	UploadQueue.mutex.Lock()
 	defer UploadQueue.mutex.Unlock()
-	return UploadQueue.queue
+	return append([]string(nil), UploadQueue.queue...)
 }

--- a/pkg/stringqueue/stringqueue_test.go
+++ b/pkg/stringqueue/stringqueue_test.go
@@ -1,0 +1,56 @@
+package stringqueue
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestAddIfAbsentConcurrent(t *testing.T) {
+	queue := NewStringQueue()
+	var workers sync.WaitGroup
+	for range 100 {
+		workers.Add(1)
+		go func() { defer workers.Done(); queue.AddIfAbsent("request.magnet") }()
+	}
+	workers.Wait()
+	if queue.Len() != 1 {
+		t.Fatalf("queue length = %d", queue.Len())
+	}
+	queue.PopTopOfQueue()
+	if !queue.AddIfAbsent("request.magnet") {
+		t.Fatal("popped path cannot be requeued")
+	}
+}
+
+func TestAddPreservesAppendSemantics(t *testing.T) {
+	queue := NewStringQueue()
+	queue.Add("a")
+	queue.Add("a")
+	queue.Add("b")
+	for _, want := range []string{"a", "a", "b"} {
+		if queue.AddIfAbsent(want) {
+			t.Fatal("duplicate insertion accepted")
+		}
+		ok, got := queue.PopTopOfQueue()
+		if !ok || got != want {
+			t.Fatalf("popped %q, want %q", got, want)
+		}
+	}
+	if !queue.AddIfAbsent("a") {
+		t.Fatal("membership remained after final duplicate popped")
+	}
+}
+
+func TestGetQueueSnapshotDoesNotAlterMembership(t *testing.T) {
+	queue := NewStringQueue()
+	queue.Add("a")
+	snapshot := queue.GetQueue()
+	snapshot[0] = "b"
+	if queue.AddIfAbsent("a") {
+		t.Fatal("snapshot mutation invalidated membership")
+	}
+	_, got := queue.PopTopOfQueue()
+	if got != "a" {
+		t.Fatalf("snapshot changed queued path to %q", got)
+	}
+}

--- a/pkg/stringqueue/types.go
+++ b/pkg/stringqueue/types.go
@@ -3,6 +3,7 @@ package stringqueue
 import "sync"
 
 type StringQueue struct {
-	queue []string
-	mutex *sync.Mutex
+	queue  []string
+	counts map[string]int
+	mutex  *sync.Mutex
 }


### PR DESCRIPTION
Premiumize API transport failures can expose the API key because the returned error contains the authenticated request URL. Separately, the blackhole worker removes failed requests from its queue while leaving their source files on disk. In watcher mode, those files may never be retried without a new event or restart. Both problems already exist on main.

This PR is based directly on main at dab7fed and addresses the pre-existing findings discussed in #66 (R1-1, R1-9, R1-11, and R1-16):

- Route all API entry points through a transport-error redaction boundary, covering raw and URL-encoded keys. The original credential-bearing error is not retained in an unwrap chain.
- Requeue failed uploads with a ten-second delay, including unfamiliar provider messages. Successful and confirmed already-uploaded requests remain terminal; missing source files are not retried forever. The normal two-second per-transfer delay is preserved.
- Classify known transfer failures in the API client and use errors.Is in the worker, rather than matching displayed error strings. Unknown wording cannot prevent retries.
- Prevent polling/retry paths from queuing duplicate work using atomic, constant-time AddIfAbsent. Existing public Add append semantics are retained. GetQueue returns a snapshot so callers cannot corrupt membership bookkeeping.
- Protect worker status reads/writes and close unsuccessful transfer response bodies.

Regression coverage includes secret redaction across all 11 API entry points, retries without a rescan, unknown provider wording, already-uploaded cleanup, removed sources, concurrent deduplication, and queue compatibility. The full scripts/verify gate passes with Go 1.24.2 and Node 22, including go vet, go test -race ./..., and backend/frontend production builds. API behavior is tested with fakes and local HTTP servers, not a live Premiumize account.

This does not include the quota-pause feature from #66. Both PRs touch the upload worker and queue, so their changes will need reconciliation when one merges first.