### PR TITLE
Release v1.5.5

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,7 +138,7 @@ serves the SPA from ./static + JSON API. No authentication by design.
 - `verify.yml` — PR-triggered, runs `scripts/verify` (below); the
   `verify (scripts/verify)` check is a required merge check on `main`
   (rule set `main-quality-gate`).
-- Version 1.5.1 is hardcoded manually (banner in `main.go`, README, git tag).
+- Version 1.5.5 is hardcoded manually (banner in `main.go`, README, git tag).
 
 ## Approved technical decisions
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
 # Premiumizearr-Nova
-## Build 1.5.1
+## Build 1.5.5
 
 [![Build](https://github.com/ensingerphilipp/premiumizearr-nova/actions/workflows/build.yml/badge.svg)](https://github.com/ensingerphilipp/premiumizearr-nova/actions/workflows/build.yml)
 
 *BUGFIX Release:* 
-* Prevent Download Lockup on orphaned broken links
-* More graceful Downloads (cooldown before retrying on broken downloadlinks)
-* Fix Subfolder handling
-* Improve Download Cleanup
+* Fix transfer folder not being applied to new uploads (multipart field)
+* Fix crash when the web UI queries blackhole status before startup completes
+* Fix SimultaneousDownloads limit being miscounted by the download count
 
-*NEW: Added Transfer-Only-Mode* ✅
-
-*NEW: Skip TLS-Certificate-Check to prevent failed 0B Downloads* ✅
-
-*NEW: Change transferfolder on Premiumize to a user-specified folder* ✅
+*NEW: Pause blackhole submissions when the Premiumize fair-use quota is exhausted* ✅
 
 ## Enjoying so far? Im running on ☕
 <a href="https://ko-fi.com/K3K819CODS"><img src="https://uploads-ssl.webflow.com/5c14e387dab576fe667689cf/5cbed8a4ae2b88347c06c923_BuyMeACoffee_blue-p-500.png" width="250px"></a>

--- a/cmd/premiumizearrd/main.go
+++ b/cmd/premiumizearrd/main.go
@@ -20,7 +20,7 @@ const asciiArt = ".______   .______      _______ .___  ___.  __   __    __  .___
 	"                                                                                          |______|   |  . `  | |  |  |  |   \\      / /  /_\\  \\   \n" +
 	"                                                                                                     |  |\\   | |  '--'  |    \\    / /  _____  \\  \n" +
 	"                                                                                                     |__| \\__|  \\______/      \\__/ /__/     \\__\\ \n" +
-	"                                                                                                      Version: 1.5.1                      \n"
+	"                                                                                                      Version: 1.5.5                      \n"
 
 func main() {
 	//Flags
@@ -30,7 +30,7 @@ func main() {
 
 	//Parse flags
 	fmt.Print(asciiArt)
-	fmt.Println("Premiumizearr-Nova Version: 1.5.1")
+	fmt.Println("Premiumizearr-Nova Version: 1.5.5")
 	flag.StringVar(&logLevel, "log", utils.EnvOrDefault("PREMIUMIZEARR_LOG_LEVEL", "info"), "Logging level: \n \tinfo,debug,trace")
 	flag.StringVar(&configFile, "config", utils.EnvOrDefault("PREMIUMIZEARR_CONFIG_DIR_PATH", "./"), "The directory the config.yml is located in")
 	flag.StringVar(&loggingDirectory, "logging-dir", utils.EnvOrDefault("PREMIUMIZEARR_LOGGING_DIR_PATH", "./"), "The directory logs are to be written to")


### PR DESCRIPTION
Version 1.5.1 -> 1.5.5. Bumps the version in the main.go banner and Println, the README Build heading, and the ARCHITECTURE.md version statement; updates the README release notes to reflect the changes since 1.5.1. Local scripts/verify passes on this head. Tag v1.5.5 will be pushed to the merged commit after merge to trigger the goreleaser Docker/package build.

Generated with Qwen Code (2-shotted by Qwen-Coder)